### PR TITLE
Oprava hlavní stránky

### DIFF
--- a/app/templates/Default/default.latte
+++ b/app/templates/Default/default.latte
@@ -13,7 +13,7 @@
 
 
 
-    <div id="front-panel-left" class="col-sm-8">
+    <div class="col-sm-8">
         <div class="row">
             <div class="well visible-xs-block visible-sm-block">
                 {include #heroUnit}
@@ -94,7 +94,7 @@
         </div>
     </div>
 
-    <div id="front-panel-fb" class="span4">
+    <div class="col-md-4">
         <div id="fb-root"></div>
         <div class="fb-like-box hidden-sm hidden-xs" data-href="https://www.facebook.com/SkautskeOnlineUcetnictvi" data-width="330" data-height="540" data-show-faces="true" data-stream="true" data-border-color="#EEEEEE" data-header="false"></div>
     </div>

--- a/www/css/site.css
+++ b/www/css/site.css
@@ -1,24 +1,3 @@
-@media (min-width: 979px) { 
-    body {
-        padding-top: 60px; /* 60px to make the container go all the way to the bottom of the topbar */
-    }
-    #front-panel-left {
-        width: 65.812%;
-    }
-    #front-panel-fb {
-        width: 31.6239%;
-    }
-}
-@media (max-width: 978px) { 
-   
-    #front-panel-left {
-        width: 100%;
-    }
-    #front-panel-fb {
-        display: none;
-    }
-}
-
 .fail {
     background-color: #ff0000;
 }
@@ -79,7 +58,7 @@ tbody.dropableOver td {
 .roleSelect {
     font-size: 12px;
     margin: 0 4px 0;
-    
+
 }
 
 #cashbook-tabs {


### PR DESCRIPTION
Momentálně mám hlavní stránku rozbitou (sloupec s FB mám až pod tím levým) a to při zkoušce na všech desktop rozlišeních.
![image](https://cloud.githubusercontent.com/assets/5658260/18585814/63c6e2a2-7c19-11e6-8b3f-1feb34a4d4ef.png)

Zkusil jsem místo těch `.frontpage-panel-...` tříd použít normální grid z bootstrapu a nenarazil jsem na problém (zkoušel jsem v Google Chome konzoli na telefonech, tabletech i desktopu). 

Teď to vypadá takto:
![image](https://cloud.githubusercontent.com/assets/5658260/18585871/de87e770-7c19-11e6-9c8f-b080d4f03ab2.png)
