### PR TITLE
Oprava TypeErroru u mailů

### DIFF
--- a/app/model/DTO/Payment/Payment.php
+++ b/app/model/DTO/Payment/Payment.php
@@ -44,8 +44,8 @@ class Payment
         ?string $email,
         DateTimeImmutable $dueDate,
         ?int $variableSymbol,
-        $constantSymbol,
-        $note
+        ?int $constantSymbol,
+        string $note
     )
     {
         $this->name = $name;

--- a/app/model/Payment/MailingService.php
+++ b/app/model/Payment/MailingService.php
@@ -124,7 +124,7 @@ class MailingService
             DateTimeImmutable::createFromMutable($paymentRow->maturity),
             $paymentRow->vs,
             $paymentRow->ks,
-            $paymentRow->note
+            (string)$paymentRow->note
         );
         $this->send($group, $payment, $bankAccount);
 


### PR DESCRIPTION
Byla tam chyba. Note může být v DB i NULL, v DTO je to vždycky string.

Nastavil jsem explicitní přetypování NULL -> ''.

U těch stringů je to pro nás ekvivalentní, proto mi dává smysl to vynutit všude jako string.