### PR TITLE
Oprava ceny u seznamu cesťáků

### DIFF
--- a/app/model/Travel/CommandTable.php
+++ b/app/model/Travel/CommandTable.php
@@ -36,7 +36,7 @@ class CommandTable extends BaseTable
     public function getAll($unitId, $returnQuery = FALSE)
     {
         $q = $this->connection->select("com.*, con.unit_id as unitId, con.driver_name, c.type as vehicle_type, c.registration as vehicle_spz, com.place")
-            ->select("(SELECT sum(distance) FROM tc_travels WHERE command_id = com.id AND type='auv') * (amortization+(com.fuel_price * (c.consumption/100))) + (SELECT sum(distance) FROM tc_travels WHERE command_id = com.id AND type !='auv') as price")
+            ->select("(SELECT COALESCE(sum(distance), 0) FROM tc_travels WHERE command_id = com.id AND type='auv') * (amortization+(com.fuel_price * (c.consumption/100))) + (SELECT COALESCE(sum(distance), 0) FROM tc_travels WHERE command_id = com.id AND type !='auv') as price")
             ->select("(SELECT MIN(start_date) FROM tc_travels WHERE command_id = com.id) as start_date")
             ->select("(SELECT GROUP_CONCAT(tt.label SEPARATOR ', ') FROM " . self::TABLE_TC_COMMAND_TYPES . " ct LEFT JOIN " . self::TABLE_TC_TRAVEL_TYPES . " tt ON (ct.typeId = tt.type) WHERE commandId = com.id) as types")
             ->from(self::TABLE_TC_COMMANDS . " AS com")


### PR DESCRIPTION
Opravuje https://github.com/skaut/Skautske-hospodareni/issues/176

Ceny se nezobrazovaly, protože `cokoliv * NULL = NULL`.

Tady by to chtělo ten výpočet taky přesunout na jedno místo. Momentálně je na 2 (seznam, detail).