### PR TITLE
Oprava mazání mailů

### DIFF
--- a/app/AccountancyModule/presenters/BasePresenter.php
+++ b/app/AccountancyModule/presenters/BasePresenter.php
@@ -38,6 +38,10 @@ class BasePresenter extends \App\BasePresenter
     {
         parent::startup();
 
+        if($this->aid != NULL) { // Persistent parameters aren't auto-casted to int
+            $this->aid = (int)$this->aid;
+        }
+
         if (!$this->user->isLoggedIn()) {
             $this->backlink = $this->storeRequest('+ 3 days');
             if ($this->isAjax()) {


### PR DESCRIPTION
Od 087de625b5fd39491354220b155e3da965016f86 nejde mazat smtp, kvůli porovnávání $aid. Nette neumí castovat persistentní parametry na nic jinýho než `string`, tak jsem to ve startupu castnul.

P.S.: Teď se dá aspoň spolehnout na to, že $aid je v presenteru vždycky int.