### PR TITLE
Oprava chybějících názvů plateb

### DIFF
--- a/app/AccountancyModule/PaymentModule/presenters/PaymentPresenter.php
+++ b/app/AccountancyModule/PaymentModule/presenters/PaymentPresenter.php
@@ -68,11 +68,15 @@ class PaymentPresenter extends BasePresenter
     {
         $this->template->onlyOpen = $onlyOpen;
         $groups = $this->model->getGroups(array_keys($this->readUnits), $onlyOpen);
-        foreach ($groups as $gid => $g) {
-            $groups[$gid]['sumarize'] = $this->model->summarizeByState($gid);
+
+        $summarizations = [];
+        foreach($groups as $group) {
+            $summarizations[$group->getId()] = $this->model->summarizeByState($group->getId());
         }
+
         $this->template->groups = $groups;
-        $this->template->payments = $this->model->getAll(array_keys($groups), TRUE);
+        $this->template->summarizations = $summarizations;
+        $this->template->payments = $this->model->getAll(array_keys($groups));
     }
 
     public function actionDetail($id): void

--- a/app/AccountancyModule/PaymentModule/templates/Payment/default.latte
+++ b/app/AccountancyModule/PaymentModule/templates/Payment/default.latte
@@ -34,7 +34,7 @@
             </tr>
             <tr n:foreach="$groups as $g">
                 <td><a n:href="Payment:detail $g->id">{$g->name}</a></td>
-                <td n:foreach="$g->sumarize as $s" class="r">{if $s->count > 0}{$s->amount|num} ({$s->count}){else} {/if}</td>
+                <td n:foreach="$summarizations[$g->id] as $s" class="r">{if $s->count > 0}{$s->amount|num} ({$s->count}){else} {/if}</td>
                 <td>{$g->state|groupState|noescape}</td>
             </tr> 
         </table>

--- a/app/model/Payment/PaymentService.php
+++ b/app/model/Payment/PaymentService.php
@@ -163,14 +163,17 @@ class PaymentService
      */
 
     /**
-     *
-     * @param int|array(int) $unitId
-     * @param boolean $onlyOpen
-     * @return array
+     * @param int[] $unitIds
+     * @param bool $onlyOpen
+     * @return DTO\Group[]
      */
-    public function getGroups($unitId, $onlyOpen = FALSE): array
+    public function getGroups(array $unitIds, bool $onlyOpen): array
     {
-        return $this->table->getGroups($unitId, $onlyOpen);
+        $groups = $this->groups->findByUnits($unitIds, $onlyOpen);
+
+        return array_map(function(Group $group) {
+            return DTO\GroupFactory::create($group);
+        }, $groups);
     }
 
     public function createGroup(

--- a/app/model/Payment/Repositories/GroupRepository.php
+++ b/app/model/Payment/Repositories/GroupRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Model\Payment\Repositories;
 
+use Kdyby\Doctrine\Connection;
 use Kdyby\Doctrine\EntityManager;
 use Model\Payment\Group;
 use Model\Payment\GroupNotFoundException;
@@ -35,6 +36,23 @@ class GroupRepository implements IGroupRepository
 
         return $group;
     }
+
+    public function findByUnits(array $unitIds, bool $openOnly): array
+    {
+        $qb = $this->em->createQueryBuilder()
+            ->select('g')
+            ->from(Group::class, 'g')
+            ->where('g.unitId IN (:unitIds)')
+            ->setParameter('unitIds', $unitIds, Connection::PARAM_INT_ARRAY);
+
+        if($openOnly) {
+            $qb->andWhere('g.state = :state')
+                ->setParameter('state', Group::STATE_OPEN);
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+
 
     public function save(Group $group): void
     {

--- a/app/model/Payment/Repositories/IGroupRepository.php
+++ b/app/model/Payment/Repositories/IGroupRepository.php
@@ -18,6 +18,13 @@ interface IGroupRepository
     public function find(int $id): Group;
 
     /**
+     * @param int[] $unitIds
+     * @param bool $openOnly
+     * @return Group[]
+     */
+    public function findByUnits(array $unitIds, bool $openOnly): array;
+
+    /**
      * @param Group $group
      */
     public function save(Group $group): void;


### PR DESCRIPTION
Volal mi jeden náš oddílák, že se mu špatně vykreslují skupiny plateb. Jsem vůl a přejmenoval jsem property i na místě, kde se ještě používala stará metoda pro získání skupin plateb. :man_facepalming: 

Přehodil jsem na novou. High priority pls :grin: 

![image](https://cloud.githubusercontent.com/assets/5658260/24549812/5d6600d6-161b-11e7-9ce0-4d318d708073.png)
