### PR TITLE
Oprava akceptačních testů

### DIFF
--- a/tests/_support/Page/Payment.php
+++ b/tests/_support/Page/Payment.php
@@ -34,7 +34,7 @@ class Payment
 
 		$date = (new \DateTime())->modify("+ $daysToNextWorkday days")->format('j');
 
-        $button = "(//td[text()='$date'])[last()]"; // Tlačítko v datepickeru
+        $button = "(//td[text()='$date' and not(contains(@class, 'disabled'))])[last()]"; // Tlačítko v datepickeru
         $I->waitForElementVisible($button);
         $I->click($button);
         $I->waitForElementNotVisible($button);


### PR DESCRIPTION
Momentálně se vezme číslo nejbližšího pracovního dne (zítřek/pondělí) a klikne se na poslední výskyt toho čísla v datepickeru. Takže když klikám např na 6, tak se klikne na to disabled tlačítko a splatnost se nenastaví a test neprojde.
![image](https://cloud.githubusercontent.com/assets/5658260/24703554/ef14e3f8-1a03-11e7-9467-41a6ce16e51c.png)
