### PR TITLE
Docker: Konfigurovatelné porty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ deployment.*
 .wercker*
 tests/_output/*
 tests/_support/_generated/*
+
+docker-compose.*.yml
+!docker-compose.yml
+!docker-compose.override.yml

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,9 @@
+version: "2"
+
+services:
+    app:
+        ports:
+            - 80:80
+    mysql:
+        ports:
+            - 3306:3306

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,6 @@ services:
             - www:/var/www
             - .:/var/www/html
             - /var/www/html/nette-temp
-        ports:
-            - 80:80
         environment:
             DEVELOPMENT_MACHINE: 'true'
         networks:
@@ -25,8 +23,6 @@ services:
         environment:
             MYSQL_ALLOW_EMPTY_PASSWORD: 'true'
             MYSQL_DATABASE: hskauting
-        ports:
-            - 3306:3306
         networks:
             main:
                 aliases:


### PR DESCRIPTION
docker-compose načítá dva soubory:
- docker-compose.yml
- docker-compose.override.yml (pokud existuje)

Když přesuneme mapování portů do toho druhýho souboru, tak bude možný spouštět docker-compose s vlastním mapováním portů (takže je možný mít třeba jiný projekt na portu 80 apod).

Pro současný používání se nic nezmění, jen přibyde možnost spustit kontejnery s na jiných portech 