### PR TITLE
Fix: Mark payments as sent

### DIFF
--- a/app/model/Payment/MailingService.php
+++ b/app/model/Payment/MailingService.php
@@ -66,6 +66,7 @@ class MailingService
         $user = $this->users->find($userId);
 
         $this->sendForPayment($payment, $group, $bankAccount, $user);
+        $this->payments->save($payment);
     }
 
     public function sendEmailForGroup(int $groupId, int $userId) : int
@@ -83,6 +84,8 @@ class MailingService
                 $sent++;
             } catch(InvalidEmailException | PaymentClosedException $e) {}
         }
+
+        $this->payments->saveMany($payments);
 
         return $sent;
     }


### PR DESCRIPTION
Od doby, co jsem předělával ten výběr mailu u plateb (zřejmě), se neoznačují platby jako odeslané, ale zůsávají jako připravené.