### PR TITLE
Fix pair button tooltip for zero groups

### DIFF
--- a/app/AccountancyModule/PaymentModule/components/templates/PairButton.latte
+++ b/app/AccountancyModule/PaymentModule/components/templates/PairButton.latte
@@ -1,4 +1,4 @@
-{var $errorMessage = $groupsCount > 1 ? 'Žádná ze skupin plateb nemá nastavený účet pro párování s FIO' : 'Skupina nemá nastavený účet pro párování s FIO'}
+{var $errorMessage = $groupsCount === 1 ? 'Skupina nemá nastavený účet pro párování s FIO' : 'Žádná ze skupin plateb nemá nastavený účet pro párování s FIO'}
 <div class="btn-group" {if !$canPair}title="{$errorMessage}" rel="tooltip"{/if}>
     <a n:href="pair!" n:class="!$canPair ? disabled, btn, btn-primary">
         <i class="glyphicon glyphicon-resize-small"></i> Párovat platby


### PR DESCRIPTION
Pokud někdo má 0 platebních skupin, tak se zobrazuje text pro 1 platbu

![image](https://user-images.githubusercontent.com/5658260/31087157-47804f2a-a79c-11e7-8730-ad166a14c29e.png)
