### PR TITLE
Oprava součtů po kategoriích

### DIFF
--- a/app/model/Export/ExportService.php
+++ b/app/model/Export/ExportService.php
@@ -228,20 +228,4 @@ class ExportService
         return $template;
     }
 
-    private function getCategories(ObjectType $type): array
-    {
-        $categories = $this->categories->findByObjectType($type);
-        $result = [
-            Operation::INCOME => [],
-            Operation::EXPENSE => [],
-        ];
-
-        foreach($categories as $category) {
-            $operation = $category->getOperationType()->getValue();
-            $result[$operation][$category->getShortcut()] = 0;
-        }
-
-        return $categories;
-    }
-
 }


### PR DESCRIPTION
Byl tam problém, že jsem při počítání součtu indexoval omylem pomocí klasických 0...n indexů místo ID kategorií.

Viz. pokladní kniha: [chyba-hskauting-akce.pdf](https://github.com/skaut/Skautske-hospodareni/files/1394617/chyba-hskauting-akce.pdf)

Předtím:
![image](https://user-images.githubusercontent.com/5658260/31719014-55be2bde-b412-11e7-888f-7126fb4faa7e.png)

Teď:
![image](https://user-images.githubusercontent.com/5658260/31719000-4992867a-b412-11e7-9c79-ff6fdd8b116e.png)
