### PR TITLE
Delete NOT matching releases

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -91,7 +91,7 @@
     <target name="deploy:cleanup">
         <echo message="Getting previous releases"/>
 
-        <property name="command" value="ssh -p ${deploy.ssh.port} ${deploy.ssh.target} 'ls ${deploy.releasesDir}' | grep -i '^${deploy.releaseHash}$'"/>
+        <property name="command" value="ssh -p ${deploy.ssh.port} ${deploy.ssh.target} 'ls ${deploy.releasesDir}' | grep -v '^${deploy.releaseHash}$'"/>
         <echo message="${command}"/>
         <exec outputProperty="previousReleases" command="${command}" checkreturn="true" passthru="true"/>
 


### PR DESCRIPTION
Byl tam špatnej option `-i` místo `-v` u grepu, takže to našlo pouze ten aktuální release a ten to smazalo