### PR TITLE
Přesun dokladů přes Cashbook

### DIFF
--- a/app/model/Cashbook/Cashbook/Chit.php
+++ b/app/model/Cashbook/Cashbook/Chit.php
@@ -4,11 +4,13 @@ namespace Model\Cashbook\Cashbook;
 
 use Cake\Chronos\Date;
 use Model\Cashbook\Cashbook;
+use Model\Cashbook\Operation;
+use Model\Cashbook\Category as CategoryAggregate;
 
 class Chit
 {
 
-    /** @var int */
+    /** @var int|NULL */
     private $id;
 
     /** @var Cashbook */
@@ -37,6 +39,12 @@ class Chit
      * @var int|NULL
      */
     private $locked;
+
+    /** @var int|NULL */
+    private $budgetCategoryIn;
+
+    /** @var int|NULL */
+    private $budgetCategoryOut;
 
     public function __construct(
         Cashbook $cashbook,
@@ -74,6 +82,10 @@ class Chit
 
     public function getId(): int
     {
+        if ($this->id === NULL) {
+            throw new \RuntimeException('ID not set');
+        }
+
         return $this->id;
     }
 
@@ -115,6 +127,30 @@ class Chit
     public function getCategory(): Category
     {
         return $this->category;
+    }
+
+    public function copyToCashbook(Cashbook $newCashbook): self
+    {
+        $newChit = clone $this;
+        $newChit->id = NULL;
+        $newChit->cashbook = $newCashbook;
+
+        return $newChit;
+    }
+
+    public function copyToCashbookWithUndefinedCategory(Cashbook $newCashbook): self
+    {
+        $newChit = $this->copyToCashbook($newCashbook);
+        $operation = $newChit->category->getOperationType();
+
+        $newChit->category = new Category(
+            $operation->equalsValue(Operation::INCOME)
+                ? CategoryAggregate::UNDEFINED_INCOME_ID
+                : CategoryAggregate::UNDEFINED_EXPENSE_ID,
+            $operation
+        );
+
+        return $newChit;
     }
 
 }

--- a/app/model/Cashbook/Commands/Cashbook/MoveChitsToDifferentCashbook.php
+++ b/app/model/Cashbook/Commands/Cashbook/MoveChitsToDifferentCashbook.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Model\Cashbook\Commands\Cashbook;
+
+use Model\Cashbook\Handlers\Cashbook\MoveChitsToDifferentCashbookHandler;
+
+/**
+ * @see MoveChitsToDifferentCashbookHandler
+ */
+final class MoveChitsToDifferentCashbook
+{
+
+    /** @var int[] */
+    private $chitIds;
+
+    /** @var int */
+    private $sourceCashbookId;
+
+    /** @var int */
+    private $targetCashbookId;
+
+    /**
+     * @param int[] $chitIds
+     */
+    public function __construct(array $chitIds, int $sourceCashbookId, int $targetCashbookId)
+    {
+        $this->chitIds = $chitIds;
+        $this->sourceCashbookId = $sourceCashbookId;
+        $this->targetCashbookId = $targetCashbookId;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getChitIds(): array
+    {
+        return $this->chitIds;
+    }
+
+    public function getSourceCashbookId(): int
+    {
+        return $this->sourceCashbookId;
+    }
+
+    public function getTargetCashbookId(): int
+    {
+        return $this->targetCashbookId;
+    }
+
+}

--- a/app/model/Cashbook/Handlers/Cashbook/MoveChitsToDifferentCashbookHandler.php
+++ b/app/model/Cashbook/Handlers/Cashbook/MoveChitsToDifferentCashbookHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Model\Cashbook\Handlers\Cashbook;
+
+use Model\Cashbook\Commands\Cashbook\MoveChitsToDifferentCashbook;
+use Model\Cashbook\Repositories\ICashbookRepository;
+
+final class MoveChitsToDifferentCashbookHandler
+{
+
+    /** @var ICashbookRepository */
+    private $cashbooks;
+
+    public function __construct(ICashbookRepository $cashbooks)
+    {
+        $this->cashbooks = $cashbooks;
+    }
+
+    public function handle(MoveChitsToDifferentCashbook $command): void
+    {
+        $sourceCashbook = $this->cashbooks->find($command->getSourceCashbookId());
+        $targetCashbook = $this->cashbooks->find($command->getTargetCashbookId());
+
+        $targetCashbook->copyChitsFrom($command->getChitIds(), $sourceCashbook);
+
+        foreach ($command->getChitIds() as $chitId) {
+            $sourceCashbook->removeChit($chitId);
+        }
+
+        $this->cashbooks->save($targetCashbook);
+        $this->cashbooks->save($sourceCashbook);
+    }
+
+}

--- a/app/model/Infrastructure/mapping/Cashbook/Model.Cashbook.Cashbook.Chit.dcm.yml
+++ b/app/model/Infrastructure/mapping/Cashbook/Model.Cashbook.Cashbook.Chit.dcm.yml
@@ -23,6 +23,14 @@ Model\Cashbook\Cashbook\Chit:
             column: '`lock`'
             type: integer
             nullable: true
+        budgetCategoryIn:
+            type: integer
+            column: budgetCategoryIn
+            nullable: true
+        budgetCategoryOut:
+            type: integer
+            column: budgetCategoryOut
+            nullable: true
 
     embedded:
         amount:

--- a/tests/integration/Cashbook/Handlers/MoveChitsToDifferentCashbookHandlerTest.neon
+++ b/tests/integration/Cashbook/Handlers/MoveChitsToDifferentCashbookHandlerTest.neon
@@ -1,0 +1,7 @@
+services:
+    - Model\Infrastructure\Repositories\Cashbook\CashbookRepository
+    - class: Model\Cashbook\Handlers\Cashbook\MoveChitsToDifferentCashbookHandler
+      tags: [commandBus.handler]
+
+includes:
+    - ../../config/doctrine.neon

--- a/tests/integration/Cashbook/Handlers/MoveChitsToDifferentCashbookHandlerTest.php
+++ b/tests/integration/Cashbook/Handlers/MoveChitsToDifferentCashbookHandlerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Model\Cashbook\Handlers;
+
+use Cake\Chronos\Date;
+use Mockery as m;
+use Model\Cashbook\Cashbook;
+use Model\Cashbook\Cashbook\CashbookType;
+use Model\Cashbook\Commands\Cashbook\MoveChitsToDifferentCashbook;
+use Model\Cashbook\ICategory;
+use Model\Cashbook\Operation;
+use Model\Cashbook\Repositories\ICashbookRepository;
+
+final class MoveChitsToDifferentCashbookHandlerTest extends \CommandHandlerTest
+{
+
+    private const TARGET_CASHBOOK_ID = 2;
+    private const SOURCE_CASHBOOK_ID = 1;
+
+    /** @var ICashbookRepository */
+    private $cashbooks;
+
+
+    public function testMovingChits(): void
+    {
+        $type = CashbookType::get(CashbookType::EVENT);
+        $this->cashbooks->save(new Cashbook(self::TARGET_CASHBOOK_ID, $type));
+        $sourceCashbook = new Cashbook(self::SOURCE_CASHBOOK_ID, $type);
+
+        for($i = 0; $i < 3; $i++) {
+            $sourceCashbook->addChit(NULL, new Date(), NULL, new Cashbook\Amount('100'), 'test', $this->mockCategory());
+        }
+
+        $this->cashbooks->save($sourceCashbook);
+
+        $this->commandBus->handle(
+            new MoveChitsToDifferentCashbook([1, 3], self::SOURCE_CASHBOOK_ID, self::TARGET_CASHBOOK_ID)
+        );
+
+        $this->entityManager->clear();
+
+        $sourceCashbook = $this->cashbooks->find(self::SOURCE_CASHBOOK_ID);
+        $targetCashbook = $this->cashbooks->find(self::TARGET_CASHBOOK_ID);
+
+        $this->assertCount(1, $sourceCashbook->getChits());
+        $this->assertCount(2, $targetCashbook->getChits());
+    }
+
+    protected function getTestedEntites(): array
+    {
+        return [
+            Cashbook::class,
+            Cashbook\Chit::class,
+        ];
+    }
+
+    protected function _before()
+    {
+        $this->tester->useConfigFiles([__DIR__ . '/MoveChitsToDifferentCashbookHandlerTest.neon']);
+        parent::_before();
+        $this->cashbooks = $this->tester->grabService(ICashbookRepository::class);
+    }
+
+    private function mockCategory(): ICategory
+    {
+        return m::mock(ICategory::class, [
+            'getId' => 123,
+            'getOperationType' => Operation::get(Operation::INCOME),
+        ]);
+    }
+
+}


### PR DESCRIPTION
Funkčně téměř stejný. 2 změny:
- zachovávají se kategorie při přesunu mezi oddíl<->oddíl a středisko<->středisko, ale v UI tuto možnost stejně nemáme :man_shrugging: 
- nejedná se o přesun, ale o kopii + smazání původního dokladu -> doklad má nové ID

Fixes #383