### PR TITLE
string instead of null

### DIFF
--- a/app/AccountancyModule/Traits/ParticipantTrait.php
+++ b/app/AccountancyModule/Traits/ParticipantTrait.php
@@ -111,7 +111,7 @@ trait ParticipantTrait
                 if (! property_exists($b, $sort)) {
                     return false;
                 }
-                return $isNumeric ? $a->{$sort} > $b->{$sort} : strcasecmp($a->{$sort}, $b->{$sort});
+                return $isNumeric ? $a->{$sort} > $b->{$sort} : strcasecmp($a->{$sort} ?? "", $b->{$sort} ?? "");
             }
         );
     }


### PR DESCRIPTION
TypeError: strcasecmp() expects parameter 2 to be string, null given in /home/vu008930/releases/20180717-0641-3cb5cac/app/AccountancyModule/Traits/ParticipantTrait.php:114