### PR TITLE
fix type

### DIFF
--- a/app/AccountancyModule/TravelModule/presenters/ContractPresenter.php
+++ b/app/AccountancyModule/TravelModule/presenters/ContractPresenter.php
@@ -132,9 +132,9 @@ class ContractPresenter extends BasePresenter
         $since = \DateTimeImmutable::createFromMutable($v->start);
 
         $passenger = new Passenger(
-            $v->passengerName,
-            $v->passengerContact,
-            $v->passengerAddress,
+            (string) $v->passengerName,
+            (string) $v->passengerContact,
+            (string) $v->passengerAddress,
             \DateTimeImmutable::createFromMutable($v->passengerBirthday)
         );
 


### PR DESCRIPTION
TypeError: Argument 2 passed to Model\Travel\Contract\Passenger::__construct() must be of the type string, integer given, called in /home/vu008930/releases/20180717-1943-2ccb953/app/AccountancyModule/TravelModule/presenters/ContractPresenter.php on line 138 in /home/vu008930/releases/20180717-1943-2ccb953/app/model/Travel/Contract/Passenger.php:31