### PR TITLE
Pro multiplier použít UUID bez pomlček

### DIFF
--- a/app/AccountancyModule/UnitAccountModule/presenters/ChitPresenter.php
+++ b/app/AccountancyModule/UnitAccountModule/presenters/ChitPresenter.php
@@ -31,7 +31,7 @@ class ChitPresenter extends BasePresenter
 
     /**
      * object type => [
-     *      cashbook ID => object
+     *      cashbook ID (without hyphens) => object
      * ]
      *
      * @var array<string, array<string, array>>
@@ -122,9 +122,8 @@ class ChitPresenter extends BasePresenter
         return new Multiplier(
             function (string $cashbookId) : ChitListControl {
                 $cashbookIdVo = CashbookId::fromString($cashbookId);
-
                 if (! $this->canEditCashbook($cashbookIdVo)) {
-                    throw new BadRequestException(sprintf('Cashbook #%s not found', $cashbookId), IResponse::S404_NOT_FOUND);
+                    throw new BadRequestException(sprintf('Cashbook #%s not found', $cashbookIdVo->toString()), IResponse::S404_NOT_FOUND);
                 }
 
                 return $this->chitListFactory->create($cashbookIdVo, (bool) $this->onlyUnlocked);
@@ -135,7 +134,7 @@ class ChitPresenter extends BasePresenter
     private function canEditCashbook(CashbookId $cashbookId) : bool
     {
         foreach ($this->cashbooks as $cashbookList) {
-            if (isset($cashbookList[$cashbookId->toString()])) {
+            if (isset($cashbookList[$cashbookId->withoutHyphens()])) {
                 return true;
             }
         }
@@ -170,7 +169,7 @@ class ChitPresenter extends BasePresenter
         $cashbooks = [];
         foreach ($objects as $oid => $object) {
             foreach ($this->getCashbookIds($objectType, $oid) as $cashbookId) {
-                $cashbooks[$cashbookId->toString()] = $object;
+                $cashbooks[$cashbookId->withoutHyphens()] = $object;
             }
         }
 

--- a/tests/unit/Cashbook/Cashbook/CashbookIdTest.php
+++ b/tests/unit/Cashbook/Cashbook/CashbookIdTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Model\Cashbook\Cashbook;
+
+use Codeception\Test\Unit;
+
+final class CashbookIdTest extends Unit
+{
+    private const UUID                 = '340139ce-8059-429c-ad1a-349909679619';
+    private const UUID_WITHOUT_HYPHENS = '340139ce8059429cad1a349909679619';
+    private const LEGACY_ID            = '123';
+
+    public function testFromStringWithLegacyId() : void
+    {
+        $this->assertSame(self::LEGACY_ID, CashbookId::fromString(self::LEGACY_ID)->toString());
+    }
+
+    public function testFromStringWithUuid() : void
+    {
+        $this->assertSame(self::UUID, CashbookId::fromString(self::UUID)->toString());
+    }
+
+    public function testFromStringWithUuidWithoutHyphens() : void
+    {
+        $this->assertSame(self::UUID, CashbookId::fromString(self::UUID_WITHOUT_HYPHENS)->toString());
+    }
+
+    public function testWithoutHyphensWithLegacyIdStaysTheSame() : void
+    {
+        $this->assertSame(self::LEGACY_ID, CashbookId::fromString(self::LEGACY_ID)->withoutHyphens());
+    }
+
+    public function testWithoutHyphensWithUuidRemovesHyphens() : void
+    {
+        $this->assertSame(
+            self::UUID_WITHOUT_HYPHENS,
+            CashbookId::fromString(self::UUID_WITHOUT_HYPHENS)->withoutHyphens()
+        );
+    }
+}


### PR DESCRIPTION
Na tohle jsem zapoměl zatím na všech Nette projektech, kde jsem UUID nasadil :man_facepalming: 

Komponenty v nette používají oddělovač `-`, takže UUID nelze použít pro název komponenty ([v Multiplieru](https://doc.nette.org/en/2.4/multiplier)). Stačí použít variantu bez pomlček.

CashbookId::fromString() příjmá jak variantu bez pomlček, tak i s pomlčkami. Doplnil jsem na to test, aby bylo jasný, že na to chování spoléháme. Navíc jsem doplnil metodu `CashbookId::withoutHyphens()`, která vrátí ID bez pomlček.