### PR TITLE
extend columns for categories

### DIFF
--- a/app/model/Excel/Builders/CashbookWithCategoriesBuilder.php
+++ b/app/model/Excel/Builders/CashbookWithCategoriesBuilder.php
@@ -41,7 +41,7 @@ class CashbookWithCategoriesBuilder
     private const FONT_SIZE = 8;
 
     // Coefficient for minimal size of column
-    private const COLUMN_WIDTH_COEFFICIENT = 1.1;
+    private const COLUMN_WIDTH_COEFFICIENT = 1.5;
 
     public function __construct(QueryBus $queryBus)
     {


### PR DESCRIPTION
Rozšíření sloupců s názvy kategorií. Zkoušel jsem postupně několik šířek viz obrázek.

<img width="1369" alt="pokladni-kniha-2 xlsx 2019-01-06 12-41-47" src="https://user-images.githubusercontent.com/1140123/50735536-f0993700-11b0-11e9-8a46-ce590c322ecd.png">


Closes #719 