### PR TITLE
Fix camp participants days

### DIFF
--- a/app/model/Participant/ParticipantService.php
+++ b/app/model/Participant/ParticipantService.php
@@ -26,7 +26,6 @@ use function array_diff_key;
 use function array_key_exists;
 use function array_map;
 use function array_reduce;
-use function in_array;
 use function is_array;
 use function preg_match;
 use function sprintf;
@@ -180,7 +179,7 @@ class ParticipantService extends MutableBaseService
     public function update(int $participantId, int $actionId, array $arr) : void
     {
         if ($this->typeName === 'Camp') {
-            if (in_array('days', $arr)) {
+            if (array_key_exists('days', $arr)) {
                 $sisData = [
                     'ID' => $participantId,
                     'Real' => true,


### PR DESCRIPTION
- Nefungovalo nastavení počtu dní u účastníka tábora.
- Opravil jsem rovnou i kontrolu existence `Note` pro stdClass u účastníka kde se dohledává částka

https://sentry.io/organizations/skautske-hospodareni-of/issues/923346571/?project=1328535&referrer=slack&statsPeriod=14d