### PR TITLE
Add default password to MySQL in Docker to config.sample.local.neon

### DIFF
--- a/app/config/config.sample.local.neon
+++ b/app/config/config.sample.local.neon
@@ -15,7 +15,7 @@ parameters:
     database:
         host: mysql
         user: root
-        password:
+        password: root
         name: hskauting
 
 services:


### PR DESCRIPTION
Update config.sample.local.neon to match changes to docker-compose.yml in 96c8fac6fcd1f9064e9423120ff673c7ce6a8ee0

[https://github.com/skaut/Skautske-hospodareni/blob/fef2af489dd058d36e9a8028fac5abde0a678a52/docker-compose.yml#L19-L26](https://github.com/skaut/Skautske-hospodareni/blob/fef2af489dd058d36e9a8028fac5abde0a678a52/docker-compose.yml#L19-L26)