### PR TITLE
Fix Slack configuration in config.sample.local.neon

### DIFF
--- a/app/config/config.sample.local.neon
+++ b/app/config/config.sample.local.neon
@@ -6,9 +6,6 @@ skautis:
     applicationId: 48104fe2-b447-47f5-9a26-051c710da74e
     testMode: true
 
-    slack:
-        url: null # Disable logging to slack
-
 parameters:
     sendEmail: FALSE
 
@@ -17,6 +14,9 @@ parameters:
         user: root
         password:
         name: hskauting
+
+    slack:
+        url: null # Disable logging to slack
 
 services:
     # Pro produkci


### PR DESCRIPTION
The old one triggers `Unknown configuration option 'skautis › slack'.`. Updated according to `config.test.local.neon`