### PR TITLE
disable auto filter

### DIFF
--- a/app/model/Excel/ExcelService.php
+++ b/app/model/Excel/ExcelService.php
@@ -320,7 +320,7 @@ class ExcelService
         }
         $sheet->getStyle('A1:H1')->getFont()->setBold(true);
         $sheet->getStyle('H1:H' . ($rowCnt - 1))->getFont()->setBold(true);
-        $sheet->setAutoFilter('A1:H' . ($rowCnt - 1));
+        // $sheet->setAutoFilter('A1:H' . ($rowCnt - 1));
 
         $sheet->setTitle('Evidence plateb');
     }


### PR DESCRIPTION
autofilter vrací prázné pole sloupečků a zkoušel jsem i auto-detect dle https://github.com/PHPOffice/PHPExcel/blob/develop/Documentation/markdown/Features/Autofilters/02-Setting-an-Autofilter.md ale nepomohlo. Tak bych to zatím vypnul, at to aspon generuje ten excel.