### PR TITLE
Freeznutí verze mailcatcher

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
 
     smtp:
         container_name: hskauting.smtp
-        image: tophfr/mailcatcher
+        image: tophfr/mailcatcher:0.6.5_3
         environment:
             SMTP_HOST: smtp-hospodareni.loc
         networks:

--- a/wercker.yml
+++ b/wercker.yml
@@ -10,7 +10,7 @@ build:
             MYSQL_ROOT_PASSWORD: 'root'
             MYSQL_DATABASE: hskauting
         - name: smtp-hospodareni.loc
-          id: tophfr/mailcatcher
+          id: tophfr/mailcatcher:0.6.5_3
           env:
             SMTP_HOST: smtp-hospodareni.loc
 


### PR DESCRIPTION
Vyšla nová verze https://hub.docker.com/r/tophfr/mailcatcher/tags, což nám rozbilo CI.