### PR TITLE
Odebrání read-only u volume /var/www

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
         container_name: hskauting.app
         image: fmasa/lebeda:7.3
         volumes:
-            - www:/var/www:ro
+            - www:/var/www
             - .:/var/www/html
         depends_on:
             - mysql


### PR DESCRIPTION
Tím, že tam nejde zapisovat, tak nejde používat bash_history ani composer cache