### PR TITLE
Přidání výsledků Skautis callů do Sentry

### DIFF
--- a/app/model/Infrastructure/Services/SkautisCallListener.php
+++ b/app/model/Infrastructure/Services/SkautisCallListener.php
@@ -50,6 +50,7 @@ final class SkautisCallListener
         return [
             'arguments' => $query->args,
             'time' => $query->time,
+            'result' => $query->result,
         ];
     }
 }


### PR DESCRIPTION
Momentálně víme jenom, co v tom requestu proběhlo za cally a s jakými parametry.

Je ok do Sentry logovat i výsledky? Týkalo by se to pouze requestů, kde by do Sentry šla chyba (tedy jako role, ID uživatele, atd.)

Hodilo by se třeba pro #826 