### PR TITLE
Oprava pozadí u dokladů se záporným zůstatkem

### DIFF
--- a/app/AccountancyModule/Components/Cashbook/templates/ChitListControl.latte
+++ b/app/AccountancyModule/Components/Cashbook/templates/ChitListControl.latte
@@ -1,3 +1,5 @@
+{var $isCash = $paymentMethod->equalsValue('cash')}
+
 <div class="panel panel-default">
     <div class="panel-heading">
         <div class="pull-right export-panel">
@@ -14,7 +16,7 @@
                         <input type="checkbox" name="chits-all" id="chits-all-{$paymentMethod}"
                                onclick="jqCheckAll(this.id, 'chits-'+{$paymentMethod->toString()})"
                                class="hidden-xs hidden-sm"/>
-                        <button n:if="$paymentMethod->equals($paymentMethod::CASH())" n:name="massPrintSend" title="Vytisknout vybrané"
+                        <button n:if="$isCash" n:name="massPrintSend" title="Vytisknout vybrané"
                                                        class="btn btn-info btn-xs allDependend-{$paymentMethod} hidden-xs hidden-sm"
                                                        type="submit">
                             <i class="glyphicon glyphicon-print"></i>
@@ -41,10 +43,10 @@
                 {foreach $chits as $chit}
                     {var $isIncome = $chit->isIncome()}
                     {php $balance += $isIncome ? $chit->amount->toFloat() : -$chit->amount->toFloat()}
-                    <tr n:class="$balance < 0 && $paymentMethod->equals($paymentMethod::CASH()) ? 'alert alert-danger'">
+                    <tr>
                         <td class="nowrap">
                             <input type="checkbox" class="hidden-xs hidden-sm" name="chits-{$paymentMethod}[]" value={$chit->id}/>
-                            <a n:if="$paymentMethod->equals($paymentMethod::CASH())"
+                            <a n:if="$isCash"
                                     href="{plink :Accountancy:CashbookExport:printChits $cashbookId, [$chit->id]}"
                                     target="_blank"
                                     class="btn btn-xs btn-info hidden-xs hidden-sm"><i
@@ -78,10 +80,10 @@
                             <td class="r">&nbsp;</td>
                             <td class="r" title="{$chit->amount->expression}">{$chit->amount->value|price}</td>
                         {/if}
-                        <td class="r">{$balance|price}</td>
+                        <td n:class="r, $balance < 0 && $isCash ? 'bg-danger'">{$balance|price}</td>
                     </tr>
                 {/foreach}
-                <tr n:class="$balance < 0 && $paymentMethod->equals($paymentMethod::CASH()) ? 'alert alert-danger'">
+                <tr>
                     <td colspan="2">&nbsp;</td>
                     <td>&nbsp;</td>
                     <td class="hidden-xs hidden-sm">&nbsp;</td>
@@ -89,7 +91,7 @@
                     <td><b>Konečný stav</b></td>
                     <td class="r">{$totalIncome|price}</td>
                     <td class="r">{$totalExpense|price}</td>
-                    <td n:class="r, ui--balance, $balance < 0 && $paymentMethod->equals($paymentMethod::CASH()) ? 'alert alert-danger'"><b>{$balance|price}</b></td>
+                    <td n:class="r, ui--balance, $balance < 0 && $isCash ? 'bg-danger'"><b>{$balance|price}</b></td>
                 </tr>
                 <tbody>
             </table>


### PR DESCRIPTION
Dříve jsme měli zvýrazněný pouze zůstatek, ale pak se změnou použité HTML třídy došlo k podbarvení celého řádku

### Předtím
![image](https://user-images.githubusercontent.com/5658260/56761730-60522280-679e-11e9-8b71-6938b56a46cd.png)

### Teď
![image](https://user-images.githubusercontent.com/5658260/56761714-54666080-679e-11e9-8b36-9c709308268a.png)
