### PR TITLE
Oprava zobrazovaného typu dopravního prostředku u cest

### DIFF
--- a/app/AccountancyModule/TravelModule/presenters/DefaultPresenter.php
+++ b/app/AccountancyModule/TravelModule/presenters/DefaultPresenter.php
@@ -98,6 +98,7 @@ class DefaultPresenter extends BasePresenter
         $this->template->setParameters([
             'command'    => $command,
             'vehicle'    => $vehicle,
+            'types'      => $command->getTransportTypePairs(),
             'isEditable' => $this->isCommandEditable($command->getId()),
             'travels'    => $this->travelService->getTravels($command->getId()),
         ]);


### PR DESCRIPTION
Aktuálně je ten sloupec prázdný, protože proměnná `$types` už neexistuje.

Problémový řádek: https://github.com/skaut/Skautske-hospodareni/blob/ade1b3e22b3801b9ff7713dc25de37f955349188/app/AccountancyModule/TravelModule/templates/Default/detail.latte#L88

![image](https://user-images.githubusercontent.com/5658260/56867187-c7f8af80-69e2-11e9-9ae4-57ee85e636b5.png)
