### PR TITLE
Fix chits export for troop cashbooks

### DIFF
--- a/app/model/Cashbook/ReadModel/QueryHandlers/Pdf/ExportChitsHandler.php
+++ b/app/model/Cashbook/ReadModel/QueryHandlers/Pdf/ExportChitsHandler.php
@@ -90,7 +90,9 @@ class ExportChitsHandler
 
         $template = [];
 
-        $eventService = $this->serviceFactory->create(ucfirst($cashbook->getType()->getValue()));
+        $eventService = $this->serviceFactory->create(
+            ucfirst($cashbook->getType()->getSkautisObjectType()->toString())
+        );
 
         $skautisId                = $this->queryBus->handle(new SkautisIdQuery($query->getCashbookId()));
         $event                    = $eventService->get($skautisId);


### PR DESCRIPTION
Closes [Sentry/1040199115](https://sentry.io/organizations/skautske-hospodareni-of/issues/1040199115)

Cashbook type for troop units is "troop".
EventService excepts "unit" for all unit types.