### PR TITLE
Znemožnění výběru víkendu pro datum splatnosti v UI

### DIFF
--- a/frontend/ts/datePicker.ts
+++ b/frontend/ts/datePicker.ts
@@ -22,5 +22,6 @@ export function initializeDatePicker(element: HTMLElement): void {
         },
         format: moment.localeData().longDateFormat('L'),
         firstDay: 1,
+        disableWeekends: true,
     });
 }


### PR DESCRIPTION
Momentálně validujeme platné datum splatnosti pouze server-side. Tohle přidává deaktivaci víkendů, jako to bylo ve starém bootstrap-datepickeru.

![image](https://user-images.githubusercontent.com/5658260/60813545-49637f80-a194-11e9-9e79-e64c8bac411a.png)
