### PR TITLE
Předávání Sentry dsn z CI

### DIFF
--- a/app/config/config.production.local.neon
+++ b/app/config/config.production.local.neon
@@ -11,7 +11,7 @@ parameters:
 
     sendEmail: true
     sentry:
-        dsn: "https://4c569d4cbda54f908d83d4b4a1959826@sentry.io/1328535"
+        dsn: "__CONFIG_SENTRY_DSN__"
 
 services:
     # Passes notices and warning to Monolog


### PR DESCRIPTION
Část #797 

Momentálně je Sentry DSN hardcoded v `config.production.local.neon`. Fakticky se jedná o token umožňující sypat do Sentry eventy, založil jsem nový DSN, přidal do Werckeru a po mergnutí smažu původní.