### PR TITLE
Unikátní URL pro JS bundly

### DIFF
--- a/app/presenters/BasePresenter.php
+++ b/app/presenters/BasePresenter.php
@@ -122,10 +122,14 @@ abstract class BasePresenter extends Nette\Application\UI\Presenter
 
         $presenterNameParts = explode(':', $this->getName());
 
+        $parameters = $this->context->getParameters();
+
         $this->template->setParameters([
             'module' => $presenterNameParts[1] ?? null,
             'presenterName' => $presenterNameParts[array_key_last($presenterNameParts)],
             'linkGenerator' => $this->linkGenerator,
+            'productionMode' => $parameters['productionMode'],
+            'wwwDir' => $parameters['wwwDir'],
         ]);
 
         if (! $this->getUser()->isLoggedIn()) {

--- a/app/templates/@layout2.latte
+++ b/app/templates/@layout2.latte
@@ -7,7 +7,7 @@
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
 
-    {if $presenter->context->parameters['productionMode']}
+    {if $productionMode}
         <script n:syntax="off">
             ga = function (){ga.q.push(arguments)};
             ga.q = [];
@@ -92,6 +92,7 @@
             <a href="https://headwayapp.co/skautske-hospodareni-changelog" target="_blank" class="ml-3">Changelog</a>
         </small>
     </footer>
-    <script type="text/javascript" src="/js/app.min.js"></script>
+    {var $jsBundle = '/js/app.min.js'}
+    <script type="text/javascript" src="{$jsBundle}?{md5_file($wwwDir . '/' . $jsBundle)}"></script>
 </body>
 </html>


### PR DESCRIPTION
Momentálně má JS bundle vždy stejný název, což vede k tomu, že zůstává v cache prohlížeče a uživatelé tak nemají aktuální JS (což se může projevit mnoha způsoby - nefunkční prvky, chybějící ikony, ...).

Přihodil jsem na konec URL md5 hash souboru.