### PR TITLE
Zvýraznění aktivního odkazu v navigaci

### DIFF
--- a/app/AccountancyModule/PaymentModule/templates/@layout.latte
+++ b/app/AccountancyModule/PaymentModule/templates/@layout.latte
@@ -4,7 +4,7 @@
         <li n:class="nav-item, in_array($presenterName, ['Payment', 'Group', 'GroupList', 'Camp', 'Registration']) ? active">
             <a class="nav-link" n:href="GroupList:"><i class="far fa-list-alt"></i> Platební skupiny</a>
         </li>
-        <li n:class="$presenter->isLinkCurrent('BankAccounts:*') ? active">
+        <li n:class="nav-item, $presenter->isLinkCurrent('BankAccounts:*') ? active">
             <a class="nav-link" n:href="BankAccounts: unitId => $unitId"><i class="fas fa-university"></i> Bankovní účty</a>
         </li>
         <li n:class="nav-item, $presenter->isLinkCurrent('Mail:*') ? active">

--- a/app/AccountancyModule/TravelModule/templates/@layout.new.latte
+++ b/app/AccountancyModule/TravelModule/templates/@layout.new.latte
@@ -5,11 +5,11 @@
             <a class="nav-link" n:href="Default:"><i class="fas fa-route"></i> Cestovní příkazy</a>
         </li>
 
-        <li n:class="in_array($presenterName, ['Vehicle', 'VehicleList'], true) ? active">
+        <li n:class="nav-item, in_array($presenterName, ['Vehicle', 'VehicleList'], true) ? active">
             <a class="nav-link" n:href="VehicleList:"><i class="fas fa-car"></i> Vozidla</a>
         </li>
 
-        <li n:class="$presenterName === 'Contract' ? active">
+        <li n:class="nav-item, $presenterName === 'Contract' ? active">
             <a class="nav-link" n:href="Contract:"><i class="fas fa-file-contract"></i> Smlouvy</a>
         </li>
     </ul>

--- a/app/AccountancyModule/UnitAccountModule/templates/@layout.new.latte
+++ b/app/AccountancyModule/UnitAccountModule/templates/@layout.new.latte
@@ -4,7 +4,7 @@
         <li n:class="nav-item, $presenterName === 'Cashbook' ? active">
             <a class="nav-link" n:href="Cashbook:"><i class="fas fa-clipboard-list"></i> Evidence plateb</a>
         </li>
-        <li n:class="$presenterName === 'Chit' ? active">
+        <li n:class="nav-item, $presenterName === 'Chit' ? active">
             <a class="nav-link" n:href="Chit:"><i class="fas fa-book"></i> Přehled dokladů</a>
         </li>
         <li n:class="nav-item, $presenterName === 'Budget' ? active">

--- a/frontend/app.scss
+++ b/frontend/app.scss
@@ -37,3 +37,16 @@ body > footer {
 .w-18 {
   width: 18%;
 }
+
+.navbar-light {
+  padding-bottom: 0;
+  .nav-item {
+    padding-bottom: $navbar-padding-y;
+
+    &.active {
+      box-sizing: border-box;
+      padding-bottom: $navbar-brand-padding-y;
+      border-bottom: 2px solid $primary;
+    }
+  }
+}


### PR DESCRIPTION
Postupně zjišťuju, že aktivní a neaktivní linky jsou docela blbě rozeznatelný. Navrhuju přidat 2px rámeček k aktivnímu odkazu. IMO to dost zvýrazňuje ten odkaz aniž by to bylo do očí.

Předtím
![image](https://user-images.githubusercontent.com/5658260/65524828-c7f7cf80-deee-11e9-95c3-b818ffcb27e1.png)

Potom
![image](https://user-images.githubusercontent.com/5658260/65524862-d9d97280-deee-11e9-8b35-28ddc730a4ac.png)
