### PR TITLE
Použití netteForms.js z vendor

### DIFF
--- a/frontend/ts/netteForms.ts
+++ b/frontend/ts/netteForms.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import netteForms from 'nette-forms';
+import netteForms from '../../vendor/nette/forms/src/assets/netteForms';
 interface NetteForms {
     showFormErrors(form: HTMLFormElement, messages: { element: Element, message: string }[]): void;
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
         "bootstrap.native": "^2.0.27",
         "moment": "^2.24.0",
         "naja": "^1.6.0",
-        "nette-forms": "^2.4.9",
         "nprogress": "^0.2.0",
         "pikaday": "^1.8.0",
         "postcss-cli": "^6.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3614,11 +3614,6 @@ neo-async@^2.5.0, neo-async@^2.6.1:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
-nette-forms@^2.4.9:
-  version "2.4.9"
-  resolved "https://registry.yarnpkg.com/nette-forms/-/nette-forms-2.4.9.tgz#a5f6fa4600eea03be2fa25472d8b55753b76f4dc"
-  integrity sha512-uezQ4b+yn9e91u7RVi2DTddzybbSotilkEF8ZoyefQ+KmmrZj9sCg/PkNu7BgUFrI3KsNEBEpDcwnmo7A/hxvA==
-
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"


### PR DESCRIPTION
Takhle se nám nebudou rozjíždět verze mezi Nette/Forms používanými v JS a v PHP 