### PR TITLE
Oprava nabízených bankovních účtů a mailů u platebních skupin s více jednotkami

### DIFF
--- a/app/AccountancyModule/PaymentModule/components/GroupForm.php
+++ b/app/AccountancyModule/PaymentModule/components/GroupForm.php
@@ -344,7 +344,7 @@ final class GroupForm extends BaseControl
             $unit = $units[$credentials->getUnitId()];
             assert($unit instanceof Unit);
 
-            $items[$unit->getDisplayName()][$credentials->getId()] = $credentials->getUsername();
+            $items[$unit->getDisplayName()][$credentials->getId()] = $credentials->getSender();
         }
 
         return $items;

--- a/app/AccountancyModule/PaymentModule/components/GroupForm.php
+++ b/app/AccountancyModule/PaymentModule/components/GroupForm.php
@@ -142,13 +142,7 @@ final class GroupForm extends BaseControl
             ->setDisabled($this->groupId !== null && $this->model->getMaxVariableSymbol($this->groupId) !== null)
             ->setNullable();
 
-        $bankAccounts     = $this->bankAccounts->findByUnit($this->unitId);
-        $bankAccountItems = [];
-        foreach ($bankAccounts as $bankAccount) {
-            $bankAccountItems[$bankAccount->getId()] = $bankAccount->getName();
-        }
-
-        $form->addSelect('bankAccount', 'Bankovní účet', $bankAccountItems)
+        $form->addSelect('bankAccount', 'Bankovní účet', $this->bankAccountItems())
             ->setRequired(false)
             ->setPrompt('Vyberte bankovní účet');
 
@@ -316,5 +310,21 @@ final class GroupForm extends BaseControl
             'subject' => $email->getTemplate()->getSubject(),
             'body' => $email->getTemplate()->getBody(),
         ];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function bankAccountItems() : array
+    {
+        $bankAccounts = $this->bankAccounts->findByUnit($this->unitId);
+
+        $items = [];
+
+        foreach ($bankAccounts as $bankAccount) {
+            $items[$bankAccount->getId()] = $bankAccount->getName();
+        }
+
+        return $items;
     }
 }

--- a/app/AccountancyModule/PaymentModule/components/GroupUnitControl.php
+++ b/app/AccountancyModule/PaymentModule/components/GroupUnitControl.php
@@ -122,6 +122,13 @@ class GroupUnitControl extends BaseControl
             );
         }
 
+        if ($group->getSmtpId() !== null && $groupAfterChange->getSmtpId() === null) {
+            $this->flashMessage(
+                'Email byl odebrán, protože žádná z aktuálních jednotek k němu nemá přístup',
+                'warning',
+            );
+        }
+
         $this->redrawControl();
     }
 

--- a/app/model/DTO/Payment/Mail.php
+++ b/app/model/DTO/Payment/Mail.php
@@ -32,13 +32,17 @@ class Mail
     /** @var string */
     private $secure;
 
-    public function __construct(int $id, int $unitId, string $username, string $host, string $secure)
+    /** @var string */
+    private $sender;
+
+    public function __construct(int $id, int $unitId, string $username, string $host, string $secure, string $sender)
     {
         $this->id       = $id;
         $this->unitId   = $unitId;
         $this->username = $username;
         $this->host     = $host;
         $this->secure   = $secure;
+        $this->sender   = $sender;
     }
 
     public function getId() : int
@@ -64,5 +68,10 @@ class Mail
     public function getSecure() : string
     {
         return $this->secure;
+    }
+
+    public function getSender() : string
+    {
+        return $this->sender;
     }
 }

--- a/app/model/DTO/Payment/MailFactory.php
+++ b/app/model/DTO/Payment/MailFactory.php
@@ -15,7 +15,8 @@ class MailFactory
             $credentials->getUnitId(),
             $credentials->getUsername(),
             $credentials->getHost(),
-            $credentials->getProtocol()->getValue()
+            $credentials->getProtocol()->getValue(),
+            $credentials->getSender(),
         );
     }
 }

--- a/app/model/Payment/Exception/NoAccessToMailCredentials.php
+++ b/app/model/Payment/Exception/NoAccessToMailCredentials.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Model\Payment\Exception;
+
+use Exception;
+use function implode;
+use function sprintf;
+
+final class NoAccessToMailCredentials extends Exception
+{
+    /**
+     * @param int[] $unitIds
+     */
+    public static function forUnits(array $unitIds, int $mailCredentialsId) : self
+    {
+        return new self(sprintf(
+            'Some of units %s have no access to mail credentials #%d',
+            implode(', ', $unitIds),
+            $mailCredentialsId
+        ));
+    }
+}

--- a/app/model/Payment/Handlers/Group/ChangeGroupUnitsHandler.php
+++ b/app/model/Payment/Handlers/Group/ChangeGroupUnitsHandler.php
@@ -9,6 +9,7 @@ use Model\Payment\Commands\Group\ChangeGroupUnits;
 use Model\Payment\GroupNotFound;
 use Model\Payment\Repositories\IGroupRepository;
 use Model\Payment\Services\IBankAccountAccessChecker;
+use Model\Payment\Services\IMailCredentialsAccessChecker;
 
 class ChangeGroupUnitsHandler
 {
@@ -16,12 +17,19 @@ class ChangeGroupUnitsHandler
     private $groups;
 
     /** @var IBankAccountAccessChecker */
-    private $accessChecker;
+    private $bankAccountAccessChecker;
 
-    public function __construct(IGroupRepository $groups, IBankAccountAccessChecker $accessChecker)
-    {
-        $this->groups        = $groups;
-        $this->accessChecker = $accessChecker;
+    /** @var IMailCredentialsAccessChecker */
+    private $mailCredentaccessChecker;
+
+    public function __construct(
+        IGroupRepository $groups,
+        IBankAccountAccessChecker $bankAccountAccessChecker,
+        IMailCredentialsAccessChecker $mailCredentialsAccessChecker
+    ) {
+        $this->groups                   = $groups;
+        $this->bankAccountAccessChecker = $bankAccountAccessChecker;
+        $this->mailCredentaccessChecker = $mailCredentialsAccessChecker;
     }
 
     /**
@@ -32,7 +40,11 @@ class ChangeGroupUnitsHandler
     {
         $group = $this->groups->find($command->getGroupId());
 
-        $group->changeUnits($command->getUnitIds(), $this->accessChecker);
+        $group->changeUnits(
+            $command->getUnitIds(),
+            $this->bankAccountAccessChecker,
+            $this->mailCredentaccessChecker,
+        );
 
         $this->groups->save($group);
     }

--- a/app/model/Payment/PaymentService.php
+++ b/app/model/Payment/PaymentService.php
@@ -24,6 +24,7 @@ use Model\Payment\Repositories\IGroupRepository;
 use Model\Payment\Repositories\IMemberEmailRepository;
 use Model\Payment\Repositories\IPaymentRepository;
 use Model\Payment\Services\IBankAccountAccessChecker;
+use Model\Payment\Services\IMailCredentialsAccessChecker;
 use Model\Payment\Summary;
 use Model\Payment\VariableSymbol;
 use Model\Services\Language;
@@ -60,20 +61,25 @@ class PaymentService
     /** @var IMemberEmailRepository */
     private $emails;
 
+    /** @var IMailCredentialsAccessChecker */
+    private $mailCredentialsAccessChecker;
+
     public function __construct(
         Skautis $skautis,
         IGroupRepository $groups,
         IPaymentRepository $payments,
         IBankAccountRepository $bankAccounts,
         IBankAccountAccessChecker $bankAccountAccessChecker,
-        IMemberEmailRepository $emails
+        IMemberEmailRepository $emails,
+        IMailCredentialsAccessChecker $mailCredentialsAccessChecker
     ) {
-        $this->skautis                  = $skautis;
-        $this->groups                   = $groups;
-        $this->payments                 = $payments;
-        $this->bankAccounts             = $bankAccounts;
-        $this->bankAccountAccessChecker = $bankAccountAccessChecker;
-        $this->emails                   = $emails;
+        $this->skautis                      = $skautis;
+        $this->groups                       = $groups;
+        $this->payments                     = $payments;
+        $this->bankAccounts                 = $bankAccounts;
+        $this->bankAccountAccessChecker     = $bankAccountAccessChecker;
+        $this->emails                       = $emails;
+        $this->mailCredentialsAccessChecker = $mailCredentialsAccessChecker;
     }
 
     public function findPayment(int $id) : ?DTO\Payment
@@ -157,7 +163,8 @@ class PaymentService
             $emails,
             $smtpId,
             $bankAccount,
-            $this->bankAccountAccessChecker
+            $this->bankAccountAccessChecker,
+            $this->mailCredentialsAccessChecker,
         );
 
         $this->groups->save($group);
@@ -179,7 +186,7 @@ class PaymentService
         $group       = $this->groups->find($id);
         $bankAccount = $bankAccountId !== null ? $this->bankAccounts->find($bankAccountId) : null;
 
-        $group->update($name, $paymentDefaults, $smtpId, $bankAccount, $this->bankAccountAccessChecker);
+        $group->update($name, $paymentDefaults, $smtpId, $bankAccount, $this->bankAccountAccessChecker, $this->mailCredentialsAccessChecker);
 
         foreach (EmailType::getAvailableValues() as $typeKey) {
             $type = EmailType::get($typeKey);

--- a/app/model/Payment/ReadModel/Queries/BankAccount/BankAccountsAccessibleByUnitsQuery.php
+++ b/app/model/Payment/ReadModel/Queries/BankAccount/BankAccountsAccessibleByUnitsQuery.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Model\Payment\ReadModel\Queries\BankAccount;
+
+use Model\Payment\ReadModel\QueryHandlers\BankAccount\BankAccountsAccessibleByUnitsQueryHandler;
+
+/**
+ * @see BankAccountsAccessibleByUnitsQueryHandler
+ */
+final class BankAccountsAccessibleByUnitsQuery
+{
+    /** @var int[] */
+    private $unitIds;
+
+    /**
+     * @param int[] $unitIds
+     */
+    public function __construct(array $unitIds)
+    {
+        $this->unitIds = $unitIds;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getUnitIds() : array
+    {
+        return $this->unitIds;
+    }
+}

--- a/app/model/Payment/ReadModel/Queries/MailCredentials/MailCredentialsAccessibleByGroupsQuery.php
+++ b/app/model/Payment/ReadModel/Queries/MailCredentials/MailCredentialsAccessibleByGroupsQuery.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Model\Payment\ReadModel\Queries\MailCredentials;
+
+/**
+ * @see MailCredentialsAccessibleByGroupsQueryHandler
+ */
+final class MailCredentialsAccessibleByGroupsQuery
+{
+    /** @var int[] */
+    private $unitIds;
+
+    /**
+     * @param int[] $unitIds
+     */
+    public function __construct(array $unitIds)
+    {
+        $this->unitIds = $unitIds;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getUnitIds() : array
+    {
+        return $this->unitIds;
+    }
+}

--- a/app/model/Payment/ReadModel/QueryHandlers/BankAccount/BankAccountsAccessibleByUnitsQueryHandler.php
+++ b/app/model/Payment/ReadModel/QueryHandlers/BankAccount/BankAccountsAccessibleByUnitsQueryHandler.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Model\Payment\ReadModel\QueryHandlers\BankAccount;
+
+use Model\DTO\Payment\BankAccount;
+use Model\DTO\Payment\BankAccountFactory;
+use Model\Payment\IUnitResolver;
+use Model\Payment\ReadModel\Queries\BankAccount\BankAccountsAccessibleByUnitsQuery;
+use Model\Payment\Repositories\IBankAccountRepository;
+use Model\Payment\Services\IBankAccountAccessChecker;
+use function array_map;
+use function array_unique;
+
+final class BankAccountsAccessibleByUnitsQueryHandler
+{
+    /** @var IBankAccountAccessChecker */
+    private $accessChecker;
+
+    /** @var IBankAccountRepository */
+    private $bankAccounts;
+
+    /** @var IUnitResolver */
+    private $unitResolver;
+
+    public function __construct(
+        IBankAccountAccessChecker $accessChecker,
+        IBankAccountRepository $bankAccounts,
+        IUnitResolver $unitResolver
+    ) {
+        $this->accessChecker = $accessChecker;
+        $this->bankAccounts  = $bankAccounts;
+        $this->unitResolver  = $unitResolver;
+    }
+
+    /**
+     * @return BankAccount[]
+     */
+    public function __invoke(BankAccountsAccessibleByUnitsQuery $query) : array
+    {
+        $unitIds         = $query->getUnitIds();
+        $officialUnitIds = array_unique(array_map([$this->unitResolver, 'getOfficialUnitId'], $unitIds));
+
+        $bankAccounts = [];
+
+        foreach ($officialUnitIds as $unitId) {
+            foreach ($this->bankAccounts->findByUnit($unitId) as $bankAccount) {
+                if (! $this->accessChecker->allUnitsHaveAccessToBankAccount($unitIds, $bankAccount->getId())) {
+                    continue;
+                }
+
+                $bankAccounts[] = BankAccountFactory::create($bankAccount);
+            }
+        }
+
+        return $bankAccounts;
+    }
+}

--- a/app/model/Payment/ReadModel/QueryHandlers/MailCredentials/MailCredentialsAccessibleByGroupsQueryHandler.php
+++ b/app/model/Payment/ReadModel/QueryHandlers/MailCredentials/MailCredentialsAccessibleByGroupsQueryHandler.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Model\Payment\ReadModel\QueryHandlers\MailCredentials;
+
+use Model\DTO\Payment\Mail;
+use Model\DTO\Payment\MailFactory;
+use Model\Payment\IUnitResolver;
+use Model\Payment\MailCredentials;
+use Model\Payment\ReadModel\Queries\MailCredentials\MailCredentialsAccessibleByGroupsQuery;
+use Model\Payment\Repositories\IMailCredentialsRepository;
+use Model\Payment\Services\IMailCredentialsAccessChecker;
+use function array_map;
+use function array_merge;
+use function array_unique;
+use function assert;
+
+final class MailCredentialsAccessibleByGroupsQueryHandler
+{
+    /** @var IMailCredentialsAccessChecker */
+    private $accessChecker;
+
+    /** @var IMailCredentialsRepository */
+    private $mailCredentials;
+
+    /** @var IUnitResolver */
+    private $unitResolver;
+
+    public function __construct(
+        IMailCredentialsAccessChecker $accessChecker,
+        IMailCredentialsRepository $mailCredentials,
+        IUnitResolver $unitResolver
+    ) {
+        $this->accessChecker   = $accessChecker;
+        $this->mailCredentials = $mailCredentials;
+        $this->unitResolver    = $unitResolver;
+    }
+
+    /**
+     * @return Mail[]
+     */
+    public function __invoke(MailCredentialsAccessibleByGroupsQuery $query) : array
+    {
+        $unitIds            = $query->getUnitIds();
+        $allMailCredentials = array_merge(
+            [],
+            ...$this->mailCredentials->findByUnits($this->unitsOwningMailCredentials($unitIds))
+        );
+
+        $accessibleMailCredentials = [];
+
+        foreach ($allMailCredentials as $mailCredentials) {
+            assert($mailCredentials instanceof MailCredentials);
+
+            if (! $this->accessChecker->allUnitsHaveAccessToMailCredentials($unitIds, $mailCredentials->getId())) {
+                continue;
+            }
+
+            $accessibleMailCredentials[] = MailFactory::create($mailCredentials);
+        }
+
+        return $accessibleMailCredentials;
+    }
+
+    /**
+     * @param int[] $unitIds
+     *
+     * @return int[]
+     */
+    private function unitsOwningMailCredentials(array $unitIds) : array
+    {
+        return array_unique(
+            array_merge([], $unitIds, array_map([$this->unitResolver, 'getOfficialUnitId'], $unitIds))
+        );
+    }
+}

--- a/app/model/Payment/Services/IMailCredentialsAccessChecker.php
+++ b/app/model/Payment/Services/IMailCredentialsAccessChecker.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Model\Payment\Services;
+
+use Model\Payment\MailCredentialsNotFound;
+
+interface IMailCredentialsAccessChecker
+{
+    /**
+     * @param int[] $unitIds
+     *
+     * @throws MailCredentialsNotFound
+     */
+    public function allUnitsHaveAccessToMailCredentials(array $unitIds, int $mailCredentialsId) : bool;
+}

--- a/app/model/Payment/Services/MailCredentialsAccessChecker.php
+++ b/app/model/Payment/Services/MailCredentialsAccessChecker.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Model\Payment\Services;
+
+use Model\Payment\IUnitResolver;
+use Model\Payment\MailCredentialsNotFound;
+use Model\Payment\Repositories\IMailCredentialsRepository;
+
+final class MailCredentialsAccessChecker implements IMailCredentialsAccessChecker
+{
+    /** @var IMailCredentialsRepository */
+    private $credentials;
+
+    /** @var IUnitResolver */
+    private $unitResolver;
+
+    public function __construct(IMailCredentialsRepository $credentials, IUnitResolver $unitResolver)
+    {
+        $this->credentials  = $credentials;
+        $this->unitResolver = $unitResolver;
+    }
+
+    /**
+     * @param int[] $unitIds
+     *
+     * @throws MailCredentialsNotFound
+     */
+    public function allUnitsHaveAccessToMailCredentials(array $unitIds, int $mailCredentialsId) : bool
+    {
+        $ownerUnitId = $this->credentials->find($mailCredentialsId)->getUnitId();
+
+        foreach ($unitIds as $unitId) {
+            if ($unitId === $ownerUnitId || $this->unitResolver->getOfficialUnitId($unitId) === $ownerUnitId) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/integration/Payment/BankAccountServiceTest.php
+++ b/tests/integration/Payment/BankAccountServiceTest.php
@@ -14,6 +14,7 @@ use Model\Payment\Repositories\IBankAccountRepository;
 use Model\Payment\Repositories\IGroupRepository;
 use Model\Payment\UnitResolverStub;
 use Stubs\BankAccountAccessCheckerStub;
+use Stubs\MailCredentialsAccessCheckerStub;
 
 class BankAccountServiceTest extends IntegrationTest
 {
@@ -103,7 +104,8 @@ class BankAccountServiceTest extends IntegrationTest
             $emails,
             null,
             $account,
-            new BankAccountAccessCheckerStub()
+            new BankAccountAccessCheckerStub(),
+            new MailCredentialsAccessCheckerStub(),
         );
 
         $this->groups->save($group);

--- a/tests/integration/Payment/BankServiceTest.php
+++ b/tests/integration/Payment/BankServiceTest.php
@@ -24,6 +24,7 @@ use Model\Payment\Repositories\IPaymentRepository;
 use Model\Payment\VariableSymbol;
 use Nette\Utils\Random;
 use Stubs\BankAccountAccessCheckerStub;
+use Stubs\MailCredentialsAccessCheckerStub;
 use function date;
 use function mt_rand;
 use function reset;
@@ -151,7 +152,8 @@ class BankServiceTest extends IntegrationTest
             $emails,
             null,
             $bankAccount,
-            new BankAccountAccessCheckerStub()
+            new BankAccountAccessCheckerStub(),
+            new MailCredentialsAccessCheckerStub(),
         );
 
         $this->groups->save($group);

--- a/tests/integration/Payment/UseCases/LastPairingInvalidationTest.neon
+++ b/tests/integration/Payment/UseCases/LastPairingInvalidationTest.neon
@@ -17,6 +17,7 @@ services:
       tags: [commandBus.handler]
 
     - Model\Payment\Services\BankAccountAccessChecker
+    - Stubs\MailCredentialsAccessCheckerStub
 
     - Model\Payment\UnitResolverStub
     - Model\Payment\FioClientStub

--- a/tests/integration/Payment/UseCases/LastPairingInvalidationTest.php
+++ b/tests/integration/Payment/UseCases/LastPairingInvalidationTest.php
@@ -14,6 +14,7 @@ use Model\Payment\Commands\Payment\CreatePayment;
 use Model\Payment\Commands\Payment\UpdatePayment;
 use Model\Payment\Repositories\IGroupRepository;
 use Model\Payment\Services\BankAccountAccessChecker;
+use Model\Payment\Services\IMailCredentialsAccessChecker;
 
 final class LastPairingInvalidationTest extends IntegrationTest
 {
@@ -188,7 +189,8 @@ final class LastPairingInvalidationTest extends IntegrationTest
                 [EmailType::PAYMENT_INFO => new EmailTemplate('', '')],
                 null,
                 $this->entityManager->find(BankAccount::class, 1),
-                $this->tester->grabService(BankAccountAccessChecker::class)
+                $this->tester->grabService(BankAccountAccessChecker::class),
+                $this->tester->grabService(IMailCredentialsAccessChecker::class),
             )
         );
 

--- a/tests/integration/Payment/UseCases/PaymentCompletedEmailTest.neon
+++ b/tests/integration/Payment/UseCases/PaymentCompletedEmailTest.neon
@@ -11,6 +11,7 @@ services:
     - Stubs\Skautis
     - Model\Payment\UserRepositoryStub
     - Stubs\BankAccountAccessCheckerStub
+    - Stubs\MailCredentialsAccessCheckerStub
 
     - Model\PaymentService
 

--- a/tests/integration/Payment/UseCases/RemoveGroupTest.php
+++ b/tests/integration/Payment/UseCases/RemoveGroupTest.php
@@ -15,6 +15,7 @@ use Model\Payment\Payment;
 use Model\Payment\Repositories\IGroupRepository;
 use Model\Payment\Repositories\IPaymentRepository;
 use Stubs\BankAccountAccessCheckerStub;
+use Stubs\MailCredentialsAccessCheckerStub;
 
 final class RemoveGroupTest extends IntegrationTest
 {
@@ -60,7 +61,8 @@ final class RemoveGroupTest extends IntegrationTest
             Helpers::createEmails(),
             null,
             null,
-            new BankAccountAccessCheckerStub()
+            new BankAccountAccessCheckerStub(),
+            new MailCredentialsAccessCheckerStub(),
         );
 
         $group->close(''); // only closed groups can be removed

--- a/tests/integration/Payment/UseCases/RemoveMailCredentialsTest.php
+++ b/tests/integration/Payment/UseCases/RemoveMailCredentialsTest.php
@@ -15,6 +15,7 @@ use Model\Payment\MailCredentialsNotFound;
 use Model\Payment\Repositories\IGroupRepository;
 use Model\Payment\Repositories\IMailCredentialsRepository;
 use Stubs\BankAccountAccessCheckerStub;
+use Stubs\MailCredentialsAccessCheckerStub;
 
 final class RemoveMailCredentialsTest extends IntegrationTest
 {
@@ -74,7 +75,8 @@ final class RemoveMailCredentialsTest extends IntegrationTest
             Helpers::createEmails(),
             $credentialsId,
             null,
-            new BankAccountAccessCheckerStub()
+            new BankAccountAccessCheckerStub(),
+            new MailCredentialsAccessCheckerStub(),
         );
         $this->groups->save($group);
         $this->assertSame(1, $group->getId());

--- a/tests/integration/Payment/stubs/MailCredentialsAccessCheckerStub.php
+++ b/tests/integration/Payment/stubs/MailCredentialsAccessCheckerStub.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stubs;
+
+use Model\Payment\Services\IMailCredentialsAccessChecker;
+
+final class MailCredentialsAccessCheckerStub implements IMailCredentialsAccessChecker
+{
+    /**
+     * @param int[] $unitIds
+     */
+    public function allUnitsHaveAccessToMailCredentials(array $unitIds, int $mailCredentialsId) : bool
+    {
+        return true;
+    }
+}

--- a/tests/integration/PaymentServiceTest.neon
+++ b/tests/integration/PaymentServiceTest.neon
@@ -7,6 +7,7 @@ services:
     - GuzzleHttp\Client
     - Stubs\Skautis
     - Stubs\BankAccountAccessCheckerStub
+    - Stubs\MailCredentialsAccessCheckerStub
 
     - class: Model\Payment\Handlers\Payment\CreatePaymentHandler
       tags: [commandBus.handler]

--- a/tests/unit/Payment/Services/MailCredentialsAccessCheckerTest.php
+++ b/tests/unit/Payment/Services/MailCredentialsAccessCheckerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Model\Payment\Services;
+
+use Codeception\Test\Unit;
+use DateTimeImmutable;
+use Mockery;
+use Model\Payment\MailCredentials;
+use Model\Payment\Repositories\IMailCredentialsRepository;
+use Model\Payment\UnitResolverStub;
+
+final class MailCredentialsAccessCheckerTest extends Unit
+{
+    private const MAIL_CREDENTIALS_ID = 1;
+
+    /** @var UnitResolverStub */
+    private $unitResolver;
+
+    protected function setUp() : void
+    {
+        parent::setUp();
+        $this->unitResolver = new UnitResolverStub();
+        $this->unitResolver->setOfficialUnits([
+            10 => 20,
+            11 => 20,
+            12 => 30,
+        ]);
+    }
+
+    public function testAtLeastOneUnitSameAsOwnerUnitGivesAccess() : void
+    {
+        $this->assertTrue(
+            $this->createChecker(100)
+                ->allUnitsHaveAccessToMailCredentials([100, 12], self::MAIL_CREDENTIALS_ID)
+        );
+    }
+
+    public function testAtLeastOneChildUnitOfOwnerUnitGivesAccess() : void
+    {
+        $this->assertTrue(
+            $this->createChecker(20)
+                ->allUnitsHaveAccessToMailCredentials([10, 12], self::MAIL_CREDENTIALS_ID)
+        );
+    }
+
+    public function testDifferentUnitHasNoAccess() : void
+    {
+        $this->assertFalse(
+            $this->createChecker(10)
+                ->allUnitsHaveAccessToMailCredentials([12], self::MAIL_CREDENTIALS_ID)
+        );
+    }
+
+    private function createChecker(int $mailCredentialsOwnerUnitId) : MailCredentialsAccessChecker
+    {
+        $repository = Mockery::mock(IMailCredentialsRepository::class);
+        $repository
+            ->shouldReceive('find')
+            ->once()
+            ->withArgs([self::MAIL_CREDENTIALS_ID])
+            ->andReturn(
+                new MailCredentials(
+                    $mailCredentialsOwnerUnitId,
+                    'foo@gmail.com',
+                    'foo',
+                    'bar',
+                    MailCredentials\MailProtocol::TLS(),
+                    'foo@gmail.com',
+                    new DateTimeImmutable()
+                )
+            );
+
+        return new MailCredentialsAccessChecker($repository, $this->unitResolver);
+    }
+}


### PR DESCRIPTION
Closes #793

Bankovní účty i maily jsou teď vždy nabízeny podle vazby platební skupiny na jednotky místo podle editovatelných jednotek aktuálního uživatele.

Chování:
- k bankovnímu účtu musí mít přístup všechny jednotky - zde máme obecně striktnější fungování díky možnosti ne/zpřístupnit bankovní účet podjednotkám
- k emailu stačí, aby měla přístup jakákoliv jednotka u skupiny (většina středisek má emaily spravované na úrovni střediska)