### PR TITLE
Oprava responzivity vybraných prvků

### DIFF
--- a/app/AccountancyModule/Components/templates/DataGrid.layout.latte
+++ b/app/AccountancyModule/Components/templates/DataGrid.layout.latte
@@ -1,0 +1,582 @@
+{**
+ * @param Column[]        $columns            Available columns
+ * @param Action[]        $actions            Available actions
+ * @param Export[]        $exports            Available exports
+ * @param Filter[]        $filters            Available filters
+ * @param ToolBarButton[] $toolbar_buttons    Available toolbar_buttons
+ * @param Form            $filter             Workaround for latte snippets
+ * @param Row[]           $rows               List of rows (each contain a item from data source)
+ * @param DataGrid        $control            Parent (DataGrid)
+ * @param string          $original_template  Original template file path
+ * @param string          $icon_prefix        Icon prefix (fa fa-)
+ * @param array           $columns_visibility What columns are visible
+ * @param InlineEdit|null $inlineEdit  Inline editing data
+ * @param InlineEdit|null $inlineAdd   Inline add data
+ *}
+
+<div class="datagrid datagrid-{$control->getName()}" data-refresh-state="{link refreshState!}">
+    {**
+     * Own data
+     *}
+    <div n:snippet="grid">
+        {snippetArea gridSnippets}
+            {form filter, class => 'ajax'}
+                {**
+                 * Filter form
+                 *}
+                {if $control->hasOuterFilterRendering()}
+                    {block outer-filters}
+                        <div class="row text-right datagrid-collapse-filters-button-row" n:if="$control->hasCollapsibleOuterFilters()">
+                            <div class="col-sm-12">
+                                <button class="btn btn-xs btn-primary active" type="button" data-toggle="collapse"
+                                        data-target="#datagrid-{$control->getName()}-row-filters">
+                                    <i n:block = "icon-filter"
+                                            class="{$icon_prefix}filter"></i> {='ublaboo_datagrid.show_filter'|translate}
+                                </button>
+                            </div>
+                        </div>
+
+                        {if $control->hasCollapsibleOuterFilters() && !$filter_active}
+                            {var $filter_row_class = 'row-filters collapse'}
+                        {elseif $filter_active}
+                            {var $filter_row_class = 'row-filters collapse in'}
+                        {else}
+                            {var $filter_row_class = 'row-filters'}
+                        {/if}
+                        <div class="{$filter_row_class}" id="datagrid-{$control->getName()}-row-filters">
+                            <div class="row">
+                                {var $i = 0}
+                                {var $filter_columns_class = 'col-sm-' . (12 / $control->getOuterFilterColumnsCount())}
+                                <div class="datagrid-row-outer-filters-group {$filter_columns_class}" n:foreach="$filters as $f">
+                                    {**
+                                     * Each fitler is rendered separately in its own template
+                                     *}
+                                    {var $filter_block = 'filter-' . $f->getKey()}
+                                    {var $filter_type_block = 'filtertype-' . $f->getType()}
+
+                                    {ifset #$filter_block}
+                                        {include #$filter_block, filter => $f, input => $form['filter'][$f->getKey()], outer => TRUE}
+                                    {else}
+                                        {ifset #$filter_type_block}
+                                            {include #$filter_type_block, filter => $f, input => $form['filter'][$f->getKey()], outer => TRUE}
+                                        {else}
+                                            {include $f->getTemplate(), filter => $f, input => $form['filter'][$f->getKey()], outer => TRUE}
+                                        {/ifset}
+                                    {/ifset}
+                                    {var $i = $i+1}
+                                </div>
+                                <div class="col-sm-12" n:if="!$control->hasAutoSubmit()">
+                                    <div class="text-right datagrid-manual-submit">
+                                        {input $filter['filter']['submit']}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    {/block}
+                {/if}
+
+                <div class="table-responsive">
+                    <table class="{block table-class}table table-hover table-striped table-bordered table-sm{/block}" n:snippet="table" n:block="data">
+                        <thead n:block="header">
+                        <tr class="row-group-actions" n:if="$hasGroupActions || $exports || $toolbar_buttons || $control->canHideColumns() || $inlineAdd" n:block="group-actions">
+                            <th colspan="{$control->getColumnsCount()}" class="ublaboo-datagrid-th-form-inline">
+                                {if $hasGroupActions}
+                                    {block group_actions}
+                                        {='ublaboo_datagrid.group_actions'|translate}:
+                                        {foreach $filter['group_action']->getControls() as $form_control}
+                                            {if $form_control instanceof \Nette\Forms\Controls\SubmitButton}
+                                                {input $form_control, class => 'btn btn-primary btn-sm', style => 'display:none'}
+                                            {elseif $form_control->getName() == 'group_action'}
+                                                {input $form_control, class => 'form-control input-sm form-control-sm', disabled => TRUE}
+                                            {else}
+                                                {input $form_control, style => 'display:none'}
+                                            {/if}
+                                        {/foreach}
+                                        {if $control->shouldShowSelectedRowsCount()}
+                                            <span class="datagrid-selected-rows-count"></span>
+                                        {/if}
+                                    {/block}
+                                {/if}
+
+                                <div class="datagrid-toolbar" n:if="$control->canHideColumns() || $inlineAdd || $exports || $toolbar_buttons">
+								<span n:if="$toolbar_buttons">
+									{foreach $toolbar_buttons as $toolbar_button}{$toolbar_button->renderButton()}{/foreach}
+								</span>
+
+                                    <span class="datagrid-exports" n:if="$exports" n:snippet="exports" n:block="exports">
+									{foreach $exports as $export}{$export->render()}{/foreach}
+								</span>
+
+                                    <div class="datagrid-settings" n:block="settings" n:if="$control->canHideColumns() || $inlineAdd">
+                                        {**
+                                         * Inline add
+                                         *}
+                                        {if $inlineAdd}
+                                            {$inlineAdd->renderButtonAdd()}
+                                        {/if}
+
+                                        {**
+                                         * Hideable columns
+                                         *}
+                                        <div class="btn-group">
+                                            <button type="button"
+                                                    class="btn btn-xs btn-default btn-secondary dropdown-toggle"
+                                                    data-toggle="dropdown" aria-haspopup="true"
+                                                    aria-expanded="false" n:if="$control->canHideColumns()">
+                                                <i n:block = "icon-gear" class="{$icon_prefix}gear"></i>
+                                            </button>
+                                            <ul class="dropdown-menu dropdown-menu-right dropdown-menu--grid">
+                                                <li n:foreach="$columns_visibility as $v_key => $visibility">
+                                                    {if $visibility['visible']}
+                                                        <a n:href="hideColumn!, column => $v_key"
+                                                                class="ajax dropdown-item">
+                                                            <i n:block = "icon-checked"
+                                                                    class="{$icon_prefix}check-square-o"></i>
+                                                            {include #column-header, column => $visibility['column']}
+                                                        </a>
+                                                    {else}
+                                                        <a n:href="showColumn!, column => $v_key"
+                                                                class="ajax dropdown-item">
+                                                            <i n:block = "icon-unchecked"
+                                                                    class="{$icon_prefix}square-o"></i>
+                                                            {include #column-header, column => $visibility['column']}
+                                                        </a>
+                                                    {/if}
+                                                </li>
+                                                <li role="separator" class="divider dropdown-divider"></li>
+                                                <li>
+                                                    <a n:href="showAllColumns!"
+                                                            class="ajax dropdown-item"><i n:block = "icon-eye"
+                                                                class="{$icon_prefix}eye"></i> {='ublaboo_datagrid.show_all_columns'|translate}
+                                                    </a>
+                                                </li>
+                                                <li n:if="$control->hasSomeColumnDefaultHide()">
+                                                    <a n:href="showDefaultColumns!"
+                                                            class="ajax dropdown-item"><i n:block = "icon-repeat"
+                                                                class="{$icon_prefix}repeat"></i> {='ublaboo_datagrid.show_default_columns'|translate}
+                                                    </a>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>
+                            </th>
+                        </tr>
+                        <tr n:block="header-column-row">
+                            <th n:snippet="thead-group-action" n:if="$hasGroupActions" n:attr="'rowspan=2' => !empty($filters) && !$control->hasOuterFilterRendering()"
+                                    class="col-checkbox">
+                                <input n:if="$hasGroupActionOnRows" n:class="$control->useHappyComponents() ? 'happy gray-border' , primary"
+                                        name="{$control->getName()|lower}-toggle-all" type="checkbox"
+                                        data-check="{$control->getName()}" data-check-all="{$control->getName()}">
+                            </th>
+                            {foreach $columns as $key => $column}
+                                {var $th = $column->getElementForRender('th', $key)}
+                                {$th->startTag()|noescape}
+                                {var $col_header = 'col-' . $key . '-header'}
+
+                                {**
+                                 * Column header can be defined also with block {col-<key>-header}
+                                 *}
+                                {ifset #$col_header}
+                                    {include #$col_header, column => $column}
+                                {else}
+                                    {if $column->isSortable()}
+                                        <a n:class="$column->isSortedBy() ? 'sort' : '', 'ajax'"
+                                                href="{link sort!, sort => $control->getSortNext($column)}"
+                                                id="datagrid-sort-{$key}">
+                                            {include #column-header, column => $column}
+
+                                            {if $column->isSortedBy()}
+                                                {if $column->isSortAsc()}
+                                                    <i n:block="icon-sort-up" class="{$icon_prefix}caret-up"></i>
+                                                {else}
+                                                    <i n:block="icon-sort-down" class="{$icon_prefix}caret-down"></i>
+                                                {/if}
+                                            {else}
+                                                <i n:block="icon-sort" class="{$icon_prefix}sort"></i>
+                                            {/if}
+                                        </a>
+                                    {else}
+                                        {include #column-header, column => $column}
+                                    {/if}
+                                {/ifset}
+
+                                <div class="datagrid-column-header-additions">
+                                    <div class="btn-group column-settings-menu" n:if="$control->canHideColumns()">
+                                        <a class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true"
+                                           aria-expanded="false" href="">
+                                            <i n:block="icon-caret-down" class="{$icon_prefix}caret-down"></i>
+                                        </a>
+                                        <ul class="dropdown-menu dropdown-menu--grid">
+                                            <li>
+                                                <a n:href="hideColumn!, column => $key" class="ajax dropdown-item">
+                                                    <i n:block = "icon-eye-slash"
+                                                            class="{$icon_prefix}eye-slash"></i> {='ublaboo_datagrid.hide_column'|translate}
+                                                </a>
+                                            </li>
+                                        </ul>
+                                    </div>
+
+                                    {if $control->hasColumnReset()}
+                                        <a data-datagrid-reset-filter-by-column="{$key}" n:href="resetColumnFilter!, key => $key" n:class="isset($filters[$key]) && $filters[$key]->isValueSet() ? '' : 'hidden', 'ajax'"
+                                           title="{='ublaboo_datagrid.reset_filter'|translate}">
+                                            <i n:block="icon-remove" class="{$icon_prefix}remove"></i>
+                                        </a>
+                                    {/if}
+                                </div>
+                                {$th->endTag()|noescape}
+                            {/foreach}
+                            <th n:if="$actions || $control->isSortable() || $items_detail || $inlineEdit || $inlineAdd"
+                                    class="col-action text-center">
+                                {='ublaboo_datagrid.action'|translate}
+                            </th>
+                        </tr>
+                        <tr n:block="header-filters" n:if="!empty($filters) && !$control->hasOuterFilterRendering()">
+                            {foreach $columns as $key => $column}
+                                {var $th = $column->getElementForRender('th', $key)}
+                                {$th->startTag()|noescape}
+                                {var $col_header = 'col-filter-' . $key . '-header'}
+                                {if !$control->hasOuterFilterRendering() && isset($filters[$key])}
+                                    {var $i = $filter['filter'][$key]}
+
+                                    {var $filter_block = 'filter-' . $filters[$key]->getKey()}
+                                    {var $filter_type_block = 'filtertype-' . $filters[$key]->getType()}
+
+                                    {ifset #$filter_block}
+                                        {include #$filter_block, filter => $filters[$key], input => $i, outer => FALSE}
+                                    {else}
+                                        {ifset #$filter_type_block}
+                                            {include #$filter_type_block, filter => $filters[$key], input => $i, outer => FALSE}
+                                        {else}
+                                            {include $filters[$key]->getTemplate(), filter => $filters[$key], input => $i, outer => FALSE}
+                                        {/ifset}
+                                    {/ifset}
+
+                                {/if}
+                                {$th->endTag()|noescape}
+                            {/foreach}
+                            <th n:if="$actions || $control->isSortable() || $items_detail || $inlineEdit || $inlineAdd"
+                                    class="col-action text-center">
+                                {if !$control->hasAutoSubmit() && !$control->hasOuterFilterRendering()}
+                                    {input $filter['filter']['submit']}
+                                {/if}
+                            </th>
+                        </tr>
+                        </thead>
+
+                        {block tbody}
+                            <tbody n:snippet="tbody" {if $control->isSortable()}data-sortable data-sortable-url="{plink $control->getSortableHandler()}" data-sortable-parent-path="{$control->getSortableParentPath()}"{/}>
+                            {snippetArea items}
+                                {if $inlineAdd && $inlineAdd->isPositionTop()}
+                                    {include inlineAddRow, columns => $columns}
+                                {/if}
+
+                                {if $columnsSummary && $columnsSummary->getPositionTop()}
+                                    {include columnSummary}
+                                {/if}
+
+                                {foreach $rows as $row}
+                                    {var $item = $row->getItem()}
+
+                                    {if !isset($toggle_detail)}
+                                        {if $inlineEdit && $inlineEdit->getItemId() == $row->getId()}
+                                            {php $inlineEdit->onSetDefaults($filter['inline_edit'], $item); }
+
+                                            <tr data-id="{$row->getId()}" n:snippet="item-{$row->getId()}" n:attr="$row->getControl()->attrs">
+                                                <td n:if="$hasGroupActions" class="col-checkbox"></td>
+
+                                                {foreach $columns as $key => $column}
+                                                    {var $col = 'col-' . $key}
+
+                                                    {var $td = $column->getElementForRender('td', $key, $row)}
+                                                    {var $td->class[] = 'datagrid-inline-edit'}
+                                                    {$td->startTag()|noescape}
+                                                    {if isset($filter['inline_edit'][$key])}
+                                                        {if $filter['inline_edit'][$key] instanceof \Nette\Forms\Container}
+                                                            {foreach $filter['inline_edit'][$key]->getControls() as $inlineEditControl}
+                                                                {input $inlineEditControl}
+                                                            {/foreach}
+                                                        {else}
+                                                            {input $filter['inline_edit'][$key]}
+                                                        {/if}
+                                                    {elseif $inlineEdit->showNonEditingColumns()}
+                                                        {include column-value, column => $column, row => $row, key => $key}
+                                                    {/if}
+                                                    {$td->endTag()|noescape}
+                                                {/foreach}
+
+                                                <td class="col-action col-action-inline-edit">
+                                                    {input $filter['inline_edit']['cancel'], class => 'btn btn-xs btn-danger'}
+                                                    {input $filter['inline_edit']['submit'], class => 'btn btn-xs btn-primary'}
+                                                    {input $filter['inline_edit']['_id']}
+                                                    {input $filter['inline_edit']['_primary_where_column']}
+                                                </td>
+                                            </tr>
+                                        {else}
+                                            <tr data-id="{$row->getId()}" n:snippet="item-{$row->getId()}" n:attr="$row->getControl()->attrs">
+                                                <td n:if="$hasGroupActions" class="col-checkbox">
+                                                    {if $row->hasGroupAction()}
+                                                        <input n:class="$control->useHappyComponents() ? 'happy gray-border' , primary"
+                                                                type="checkbox" data-check="{$control->getName()}"
+                                                                data-check-all-{$control->getName()|noescape}
+                                                                name="{$control->getName()|lower}_group_action_item[{$row->getId()}]">
+                                                    {/if}
+                                                </td>
+                                                {foreach $columns as $key => $column}
+                                                    {php $column = $row->applyColumnCallback($key, clone $column)}
+
+                                                    {var $td = $column->getElementForRender('td', $key, $row)}
+                                                    {$td->startTag()|noescape}
+                                                    {include column-value, column => $column, row => $row, key => $key}
+                                                    {$td->endTag()|noescape}
+                                                {/foreach}
+                                                <td n:if="$actions || $control->isSortable() || $items_detail || $inlineEdit || $inlineAdd"
+                                                        class="col-action">
+                                                    {foreach $actions as $key => $action}
+                                                        {if $row->hasAction($key)}
+                                                            {if $action->hasTemplate()}
+                                                                {include $action->getTemplate(), item => $item, (expand) $action->getTemplateVariables(), row => $row}
+                                                            {else}
+                                                                {$action->render($row)|noescape}
+                                                            {/if}
+                                                        {/if}
+                                                    {/foreach}
+                                                    <span class="handle-sort btn btn-xs btn-default btn-secondary" n:if="$control->isSortable()">
+												<i n:block = "icon-arrows-v" class="{$icon_prefix}arrows-v"></i>
+											</span>
+                                                    {if $inlineEdit && $row->hasInlineEdit()}
+                                                        {$inlineEdit->renderButton($row)|noescape}
+                                                    {/if}
+                                                    {if $items_detail && $items_detail->shouldBeRendered($row)}
+                                                        {$items_detail->renderButton($row)|noescape}
+                                                    {/if}
+                                                </td>
+                                            </tr>
+                                        {/if}
+                                    {/if}
+
+                                    {**
+                                     * Item detail
+                                     *}
+                                    {if $items_detail && $items_detail->shouldBeRendered($row)}
+                                        <tr class="row-item-detail item-detail-{$row->getId()}" n:snippet="item-{$row->getId()}-detail">
+                                            {if isset($toggle_detail) && $toggle_detail == $row->getId()}
+                                                {var $item_detail_params = ['item' => $item, '_form' => $filter] + $items_detail->getTemplateVariables()}
+
+                                                {if isset($filter['items_detail_form'])}
+                                                    {var $item_detail_params['items_detail_form'] = $filter['items_detail_form']}
+                                                {/if}
+
+                                                {ifset #detail}
+                                                    <td colspan="{$control->getColumnsCount()}">
+                                                        <div class="item-detail-content">
+                                                            {include #detail, (expand) $item_detail_params}
+                                                        </div>
+                                                    </td>
+                                                {elseif $items_detail}
+                                                    <td colspan="{$control->getColumnsCount()}">
+                                                        <div class="item-detail-content">
+                                                            {if $items_detail->getType() == 'template'}
+                                                                {include $items_detail->getTemplate(), (expand) $item_detail_params}
+                                                            {else}
+                                                                {$items_detail->render($item)|noescape}
+                                                            {/if}
+                                                        </div>
+                                                    </td>
+                                                {/ifset}
+                                            {/if}
+                                        </tr>
+                                        <tr class="row-item-detail-helper"></tr>
+                                    {/if}
+                                {/foreach}
+
+                                {if $inlineAdd && $inlineAdd->isPositionBottom()}
+                                    {include inlineAddRow, columns => $columns}
+                                {/if}
+
+                                {if $columnsSummary && !$columnsSummary->getPositionTop()}
+                                    {include columnSummary}
+                                {/if}
+
+                                {block noItems}
+                                    <tr n:if="!$rows">
+                                        <td colspan="{$control->getColumnsCount()}">
+                                            {if $filter_active}
+                                                {='ublaboo_datagrid.no_item_found_reset'|translate} <a
+                                                    class="link ajax" n:href="resetFilter!">{='ublaboo_datagrid.here'|translate}</a>.
+                                            {else}
+                                                {='ublaboo_datagrid.no_item_found'|translate}
+                                            {/if}
+                                        </td>
+                                    </tr>
+                                {/block}
+                            {/snippetArea}
+                            </tbody>
+                        {/block}
+                        {block tfoot}
+                            <tfoot n:snippet="pagination">
+                            {if $control->isPaginated() || $filter_active}
+                                <tr n:block="pagination">
+                                    <td colspan="{$control->getColumnsCount()}" n:if="!$control->isTreeView()"
+                                        class="row-grid-bottom">
+                                        <div class="col-items">
+                                            <small class="text-muted" n:if="$control->isPaginated()">
+                                                ({var $paginator = $control['paginator']->getPaginator()}
+
+                                                {if $control->getPerPage() === 'all'}
+                                                {='ublaboo_datagrid.items'|translate}: {='ublaboo_datagrid.all'|translate}
+                                                {else}
+                                                {='ublaboo_datagrid.items'|translate}: {$paginator->getOffset() > 0 ? $paginator->getOffset() + 1 : ($paginator->getItemCount() > 0 ? 1 : 0)} - {sizeof($rows) + $paginator->getOffset()}
+                                                {='ublaboo_datagrid.from'|translate} {$paginator->getItemCount()}
+                                                {/if})
+                                            </small>
+                                        </div>
+                                        <div class="col-pagination text-center">
+                                            {**
+                                            * Pagination
+                                            *}
+                                            {control paginator}
+                                        </div>
+                                        <div class="col-per-page text-right">
+                                            {**
+                                            * Items per page form (display only beside paginated grido)
+                                            *}
+                                            <a n:if="$filter_active" n:href="resetFilter!"
+                                                    class="ajax btn btn-danger btn-sm reset-filter">{='ublaboo_datagrid.reset_filter'|translate}</a>
+                                            {if $control->isPaginated()}
+                                                {input $filter['per_page'], data-autosubmit-per-page => TRUE, class => 'form-control input-sm form-control-sm'}
+                                                {input $filter['per_page_submit'], class => 'datagrid-per-page-submit'}
+                                            {/if}
+                                        </div>
+                                    </td>
+                                </tr>
+                            {/if}
+                            </tfoot>
+                        {/block}
+                    </table>
+                </div>
+            {/form}
+        {/snippetArea}
+    </div>
+</div>
+
+
+{define inlineAddRow}
+    {php $inlineAdd->onSetDefaults($filter['inline_add']); }
+
+    <tr class="datagrid-row-inline-add datagrid-row-inline-add-hidden">
+        <td n:if="$hasGroupActions" class="col-checkbox"></td>
+
+        {foreach $columns as $key => $column}
+            {var $col = 'col-' . $key}
+
+            {var $td = clone $column->getElementForRender('td', $key)}
+            {var $td->class[] = 'datagrid-inline-edit'}
+            {$td->startTag()|noescape}
+            {if isset($filter['inline_add'][$key])}
+                {if $filter['inline_add'][$key] instanceof \Nette\Forms\Container}
+                    {foreach $filter['inline_add'][$key]->getControls() as $inlineAddControl}
+                        {input $inlineAddControl}
+                    {/foreach}
+                {else}
+                    {input $filter['inline_add'][$key]}
+                {/if}
+            {/if}
+            {$td->endTag()|noescape}
+        {/foreach}
+
+        <td class="col-action col-action-inline-edit">
+            {input $filter['inline_add']['cancel']}
+            {input $filter['inline_add']['submit']}
+        </td>
+    </tr>
+{/define}
+
+
+{define columnSummary}
+
+    <tr class="datagrid-row-columns-summary" n:if="!empty($rows) && ($columnsSummary || $control->hasSomeAggregationFunction())" n:snippet="summary">
+        <td n:if="$hasGroupActions" class="col-checkbox"></td>
+
+        {if $columnsSummary && $columnsSummary->someColumnsExist($columns)}
+            {include columnsSummary, columns => $columns}
+        {/if}
+
+        {if $control->hasSomeAggregationFunction()}
+            {include aggregationFunctions, columns => $columns}
+        {/if}
+
+        <td n:if="$actions || $control->isSortable() || $items_detail || $inlineEdit || $inlineAdd"
+                class="col-action"></td>
+    </tr>
+
+{/define}
+
+
+{define columnsSummary}
+
+    {foreach $columns as $key => $column}
+        {var $td = $column->getElementForRender('td', $key)}
+
+        {$td->startTag()|noescape}
+        {$columnsSummary->render($key)}
+        {$td->endTag()|noescape}
+    {/foreach}
+
+{/define}
+
+
+{define aggregationFunctions}
+
+    {foreach $columns as $key => $column}
+        {var $td = $column->getElementForRender('td', $key)}
+
+        {$td->startTag()|noescape}
+        {if $aggregation_functions}
+            {ifset $aggregation_functions[$key]}
+                {$aggregation_functions[$key]->renderResult()|noescape}
+            {/ifset}
+        {else}
+            {$multiple_aggregation_function->renderResult($key)|noescape}
+        {/if}
+        {$td->endTag()|noescape}
+    {/foreach}
+
+{/define}
+
+
+{define column-header}
+    {if $column->isHeaderEscaped()}
+        {if $column instanceof \Nette\Utils\Html || !$column->isTranslatableHeader()}
+            {$column->getName()|noescape}
+        {else}
+            {$column->getName()|translate|noescape}
+        {/if}
+    {else}
+        {if $column instanceof \Nette\Utils\Html || !$column->isTranslatableHeader()}
+            {$column->getName()}
+        {else}
+            {$column->getName()|translate}
+        {/if}
+    {/if}
+{/define}
+
+
+{define column-value}
+    {var $col = 'col-' . $key}
+    {var $item = $row->getItem()}
+
+    {if $column->hasTemplate()}
+        {include $column->getTemplate(), row => $row, item => $item, (expand) $column->getTemplateVariables()}
+    {else}
+        {ifset #$col}
+            {include #$col, item => $item}
+        {else}
+            {if $column->isTemplateEscaped()}
+                {$column->render($row)}
+            {else}
+                {$column->render($row)|noescape}
+            {/if}
+        {/ifset}
+    {/if}
+{/define}

--- a/app/AccountancyModule/Components/templates/datagrid.latte
+++ b/app/AccountancyModule/Components/templates/datagrid.latte
@@ -1,4 +1,4 @@
-{extends $original_template}
+{extends DataGrid.layout.latte}
 
 {block table-class}table table-bordered table-striped mt-2{/block}
 

--- a/app/AccountancyModule/Components/templates/datagrid.latte
+++ b/app/AccountancyModule/Components/templates/datagrid.latte
@@ -11,7 +11,7 @@
                     {/ifset}
                 </div>
         </div>
-        <div class="text-right" n:snippet="global-actions">
+        <div class="text-md-right" n:snippet="global-actions">
             {ifset #global-actions}
                 {include #global-actions}
             {/ifset}

--- a/app/AccountancyModule/PaymentModule/templates/GroupList/default.latte
+++ b/app/AccountancyModule/PaymentModule/templates/GroupList/default.latte
@@ -55,28 +55,24 @@
 
     </div>
 
-<div class="row">
-    <div class="col-sm-12">
-    {if !empty($groups)}
-        <table class="table table-bordered table-striped">
-            <tr>
-                <th>Název</th>
-                <th>Připravené</th>
-                <th>Odeslané</th>
-                <th>Dokončené</th>
-                <th>Stav</th>
-            </tr>
-            <tr n:foreach="$groups as $g">
-                <td><a n:href="Payment:default $g->id">{$g->name}</a></td>
-                <td n:foreach="$summarizations[$g->id] as $s" class="r">{if $s->count > 0}{$s->amount|num} ({$s->count}){else} {/if}</td>
-                <td>
-                    {$g->state|groupState|noescape}
-                    <span class="text-success" title="Lze párovat s bankou" n:if="$groupsPairingSupport[$g->id] === TRUE">
-                        <span class="fas fa-university"></span>
-                    </span>
-                </td>
-            </tr> 
-        </table>
-    {/if}
-    </div>
+<div class="table-responsive" n:if="!empty($groups)">
+    <table class="table table-bordered table-striped">
+        <tr>
+            <th>Název</th>
+            <th>Připravené</th>
+            <th>Odeslané</th>
+            <th>Dokončené</th>
+            <th>Stav</th>
+        </tr>
+        <tr n:foreach="$groups as $g">
+            <td><a n:href="Payment:default $g->id">{$g->name}</a></td>
+            <td n:foreach="$summarizations[$g->id] as $s" class="r">{if $s->count > 0}{$s->amount|num} ({$s->count}){else} {/if}</td>
+            <td>
+                {$g->state|groupState|noescape}
+                <span class="text-success" title="Lze párovat s bankou" n:if="$groupsPairingSupport[$g->id] === TRUE">
+                    <span class="fas fa-university"></span>
+                </span>
+            </td>
+        </tr>
+    </table>
 </div>

--- a/app/templates/@layout2.latte
+++ b/app/templates/@layout2.latte
@@ -86,7 +86,7 @@
 
     <footer class="mt-5 py-2 text-center bg-light">
         <small class="text-muted">
-            Skautské hospodaření
+            <span class="d-block text-center d-md-inline">Skautské hospodaření</span>
             <a n:href=":Default:about" class="ml-3">O projektu</a>
             <a href="https://github.com/skaut/Skautske-hospodareni/graphs/contributors" class="ml-3">Autoři</a>
             <a href="https://github.com/skaut/Skautske-hospodareni" class="ml-3"><i class="fab fa-github"></i> Pošli PR</a>


### PR DESCRIPTION
## Použití .table-responsive pro datagridy (a tabulku skupin plateb)
Tohle furt není na telefonu dost příjemný, ale aspoň to nerozsype stránku

### Před
![image](https://user-images.githubusercontent.com/5658260/66160050-91762f00-e629-11e9-93b9-c366e9c47155.png)

### Po
![image](https://user-images.githubusercontent.com/5658260/66160071-9e931e00-e629-11e9-9ed6-e0fa00e6db37.png)

## Zarovnání doleva pro akce u gridu na mobilu
Ve chvíli, kdy ty prvky jsou pod sebou nedává smysl mít je zarovnaný doprava. To je kvůli tomuto zobrazení:
![image](https://user-images.githubusercontent.com/5658260/66160215-f16cd580-e629-11e9-9c3f-7d92626d581a.png)

### Před
![image](https://user-images.githubusercontent.com/5658260/66160125-c4b8be00-e629-11e9-8baa-7a1a9e04f05b.png)

### Po
![image](https://user-images.githubusercontent.com/5658260/66160162-d601ca80-e629-11e9-889f-0e7a4d68a969.png)

## Rozdělení patičky na dva řádky

### Před
![image](https://user-images.githubusercontent.com/5658260/66160261-077a9600-e62a-11e9-86b6-523dbaad1833.png)

### Po
![image](https://user-images.githubusercontent.com/5658260/66160306-2547fb00-e62a-11e9-9b7d-957fae0836ad.png)
