### PR TITLE
show payment group name on paired payment

### DIFF
--- a/app/AccountancyModule/PaymentModule/presenters/BankAccountsPresenter.php
+++ b/app/AccountancyModule/PaymentModule/presenters/BankAccountsPresenter.php
@@ -17,11 +17,13 @@ use Model\Payment\BankAccount\BankAccountId;
 use Model\Payment\BankAccountNotFound;
 use Model\Payment\BankAccountService;
 use Model\Payment\ReadModel\Queries\CountGroupsWithBankAccountQuery;
+use Model\Payment\ReadModel\Queries\GetGroupList;
 use Model\Payment\ReadModel\Queries\PairedPaymentsQuery;
 use Model\Payment\TokenNotSet;
 use Model\User\ReadModel\Queries\ActiveSkautisRoleQuery;
 use Model\User\SkautisRole;
 use Nette\Application\BadRequestException;
+use function array_keys;
 use function assert;
 use function sprintf;
 
@@ -177,6 +179,17 @@ class BankAccountsPresenter extends BasePresenter
 
                 $paymentsByTransaction[$payment->getTransaction()->getId()] = $payment;
             }
+
+            $groups = $this->queryBus->handle(
+                new GetGroupList(array_keys($this->unitService->getReadUnits($this->user)), false)
+            );
+
+            $groupNames = [];
+            foreach ($groups as $g) {
+                $groupNames[$g->getId()] = $g->getName();
+            }
+
+            $templateParameters['groupNames'] = $groupNames;
 
             $templateParameters['payments'] = $paymentsByTransaction;
         } catch (TokenNotSet $e) {

--- a/app/AccountancyModule/PaymentModule/templates/BankAccounts/detail.latte
+++ b/app/AccountancyModule/PaymentModule/templates/BankAccounts/detail.latte
@@ -49,7 +49,8 @@
                     {var $payment = $payments[$t->id] ?? null}
                     <td n:inner-if="$payment !== null">
                         <a href="{link Payment:default $payment->groupId}#payment-{$payment->id}" class="btn btn-xs btn-default"
-                                title='Spárováno s platbou "{$payment->name}"'>
+                                title='Spárováno {if array_key_exists($payment->getGroupId(), $groupNames)} ve skupině "{$groupNames[$payment->getGroupId()]}"{/if} s platbou "{$payment->name}"'
+                                data-toggle='tooltip'>
                             <span class="fas fa-university"></span>
                         </a>
                     </td>


### PR DESCRIPTION
close #816 

zobrazuje název skupiny ve které je to spárované, pokud máš právo na čtení dané skupiny.

<img width="259" alt="Screenshot 2019-11-17 at 22 34 26" src="https://user-images.githubusercontent.com/1140123/69014565-d06b0480-098b-11ea-97e5-33e636ee3b3d.png">
