### PR TITLE
Oprava neaktivního víkendu v datepickeru u akcí a cesťáků

### DIFF
--- a/app/AccountancyModule/Components/FormControls/DateControl.php
+++ b/app/AccountancyModule/Components/FormControls/DateControl.php
@@ -29,6 +29,20 @@ class DateControl extends DatePicker
         return $this;
     }
 
+    public function disableWeekends() : self
+    {
+        $this->addRule(function (self $control) : bool {
+            $value = $control->getValue();
+
+            return $value === null || $value->isWeekday();
+        });
+
+        $this->getControlPrototype()
+            ->setAttribute('data-disable-weekends', 'true');
+
+        return $this;
+    }
+
     public function getValue() : ?Date
     {
         $value = parent::getValue();

--- a/app/AccountancyModule/EventModule/templates/NewEvent/default.latte
+++ b/app/AccountancyModule/EventModule/templates/NewEvent/default.latte
@@ -1,5 +1,5 @@
 {block content}
-<h1 class="mt-4">Nová výprava</h1>
+<h1 class="mt-4">Nová akce</h1>
 
 <div class="row">
     <div class="col-lg-6">

--- a/app/AccountancyModule/PaymentModule/components/GroupForm.php
+++ b/app/AccountancyModule/PaymentModule/components/GroupForm.php
@@ -109,14 +109,10 @@ final class GroupForm extends BaseControl
             ->addRule(Form::FLOAT, 'Částka musí být zadaná jako číslo');
 
         $form->addDate('dueDate', 'Výchozí splatnost')
+            ->disableWeekends()
             ->setAttribute('class', 'form-control')
             ->setRequired(false)
-            ->setNullable()
-            ->addRule(function (DateControl $control) : bool {
-                $value = $control->getValue();
-
-                return $value === null || $value->isWeekday();
-            });
+            ->setNullable();
 
         $form->addText('constantSymbol', 'KS')
             ->setMaxLength(4)

--- a/app/AccountancyModule/PaymentModule/components/MassAddForm.php
+++ b/app/AccountancyModule/PaymentModule/components/MassAddForm.php
@@ -45,6 +45,7 @@ class MassAddForm extends BaseControl
             ->setAttribute('class', 'input-mini');
 
         $form->addDate('dueDate', 'Splatnost:')
+            ->disableWeekends()
             ->setAttribute('class', 'input-small');
         $form->addText('constantSymbol', 'KS:')
             ->setRequired(false)
@@ -113,6 +114,7 @@ class MassAddForm extends BaseControl
             ->addRule($form::MIN, 'Čátka musí být větší než 0', 0.01);
 
         $container->addDate('dueDate', 'Splatnost:')
+            ->disableWeekends()
             ->setAttribute('class', 'input-small')
             ->setRequired(false);
 

--- a/app/AccountancyModule/PaymentModule/components/PaymentDialog.php
+++ b/app/AccountancyModule/PaymentModule/components/PaymentDialog.php
@@ -92,6 +92,7 @@ final class PaymentDialog extends BaseControl
             ->addRule(Form::EMAIL, 'Zadaný email nemá platný formát');
 
         $form->addDate('dueDate', 'Splatnost')
+            ->disableWeekends()
             ->setRequired('Musíte vyplnit splatnost');
 
         $form->addVariableSymbol('variableSymbol', 'VS')

--- a/app/AccountancyModule/PaymentModule/presenters/RepaymentPresenter.php
+++ b/app/AccountancyModule/PaymentModule/presenters/RepaymentPresenter.php
@@ -57,6 +57,7 @@ final class RepaymentPresenter extends BasePresenter
         $form = new BaseForm();
 
         $form->addDate('date', 'Datum splatnosti:')
+            ->disableWeekends()
             ->setDefaultValue(Date::now()->addWeekday());
 
         $form->addSubmit('send', 'Odeslat platby do banky')

--- a/frontend/ts/datePicker.ts
+++ b/frontend/ts/datePicker.ts
@@ -22,6 +22,6 @@ export function initializeDatePicker(element: HTMLElement): void {
         },
         format: moment.localeData().longDateFormat('L'),
         firstDay: 1,
-        disableWeekends: true,
+        disableWeekends: element.getAttribute('data-disable-weekends') === 'true',
     });
 }


### PR DESCRIPTION
Closes https://github.com/skaut/Skautske-hospodareni/issues/1154

Kromě toho jsem (v samostatném commitu) upravil nadpis u přidávání nové akce. Bylo tam "Nová výprava" - všude jinde používáme "Akce". Stejně se název používá i ve Skautisu.