### PR TITLE
Oprava data provideru v AmountTest::testIsUsingFormula()

### DIFF
--- a/tests/unit/Cashbook/Cashbook/AmountTest.php
+++ b/tests/unit/Cashbook/Cashbook/AmountTest.php
@@ -101,7 +101,7 @@ class AmountTest extends Unit
     }
 
     /**
-     * @dataProvider getMultiplications
+     * @dataProvider getExpressions
      */
     public function testIsUsingFormula(string $expression, bool $expectedResult) : void
     {


### PR DESCRIPTION
Opravil jsem jeden test, který očividně používal špatný data provider. Ten totiž [po aktualizaci Codeception](https://github.com/skaut/Skautske-hospodareni/pull/1188) přestal kvůli nekompatibilním typům fungovat