### PR TITLE
Rozdělení táborových vratek pro děti a dospělé

### DIFF
--- a/app/model/Cashbook/ICategory.php
+++ b/app/model/Cashbook/ICategory.php
@@ -12,6 +12,8 @@ interface ICategory
     public const CATEGORY_PARTICIPANT_INCOME_ID = 1;
     public const CATEGORY_HPD_ID                = 11;
     public const CATEGORY_REFUND_ID             = 20;
+    public const CATEGORY_REFUND_CHILD_ID       = 21;
+    public const CATEGORY_REFUND_ADULT_ID       = 22;
 
     public function getId() : int;
 

--- a/app/model/Cashbook/ParticipantType.php
+++ b/app/model/Cashbook/ParticipantType.php
@@ -10,4 +10,14 @@ final class ParticipantType extends Enum
 {
     public const ADULT = 'adult';
     public const CHILD = 'child';
+
+    public static function CHILD() : self
+    {
+        return self::get(self::CHILD);
+    }
+
+    public static function ADULT() : self
+    {
+        return self::get(self::ADULT);
+    }
 }

--- a/app/model/Cashbook/ReadModel/CategoryTotalsCalculator.php
+++ b/app/model/Cashbook/ReadModel/CategoryTotalsCalculator.php
@@ -4,31 +4,65 @@ declare(strict_types=1);
 
 namespace Model\Cashbook\ReadModel;
 
+use InvalidArgumentException;
+use Model\Cashbook\CampCategory;
 use Model\Cashbook\Cashbook;
 use Model\Cashbook\Cashbook\CashbookType;
 use Model\Cashbook\ICategory;
+use Model\Cashbook\ParticipantType;
 use function array_key_exists;
+use function sprintf;
 
 final class CategoryTotalsCalculator
 {
     /**
+     * @param ICategory[] $categories
+     *
      * @return array<int, float>
      */
-    public function calculate(Cashbook $cashbook) : array
+    public function calculate(Cashbook $cashbook, array $categories) : array
     {
         $totalByCategories = $cashbook->getCategoryTotals();
 
-        if (! $cashbook->getType()->equalsValue(CashbookType::CAMP)) {
+        if ($cashbook->getType()->equalsValue(CashbookType::CAMP)) {
+            $totalByCategories = self::categorySubtract($totalByCategories, self::getCampIncomeCategoryId($categories, ParticipantType::CHILD()), ICategory::CATEGORY_REFUND_CHILD_ID);
+            $totalByCategories = self::categorySubtract($totalByCategories, self::getCampIncomeCategoryId($categories, ParticipantType::ADULT()), ICategory::CATEGORY_REFUND_ADULT_ID);
+        } else {
             if (array_key_exists(ICategory::CATEGORY_HPD_ID, $totalByCategories)) {
                 $totalByCategories[ICategory::CATEGORY_PARTICIPANT_INCOME_ID] = ($totalByCategories[ICategory::CATEGORY_PARTICIPANT_INCOME_ID] ?? 0) + $totalByCategories[ICategory::CATEGORY_HPD_ID];
                 unset($totalByCategories[ICategory::CATEGORY_HPD_ID]);
             }
-            if (array_key_exists(ICategory::CATEGORY_REFUND_ID, $totalByCategories)) {
-                $totalByCategories[ICategory::CATEGORY_PARTICIPANT_INCOME_ID] = ($totalByCategories[ICategory::CATEGORY_PARTICIPANT_INCOME_ID] ?? 0) - $totalByCategories[ICategory::CATEGORY_REFUND_ID];
-                unset($totalByCategories[ICategory::CATEGORY_REFUND_ID]);
-            }
+            $totalByCategories = self::categorySubtract($totalByCategories, ICategory::CATEGORY_PARTICIPANT_INCOME_ID, ICategory::CATEGORY_REFUND_ID);
         }
 
         return $totalByCategories;
+    }
+
+    /**
+     * @param array<int, float> $totalByCategories
+     *
+     * @return array<int, float>
+     */
+    private static function categorySubtract(array $totalByCategories, int $categoryId, int $temporaryId) : array
+    {
+        if (array_key_exists($temporaryId, $totalByCategories)) {
+            $totalByCategories[$categoryId] = ($totalByCategories[$categoryId] ?? 0) - $totalByCategories[$temporaryId];
+            unset($totalByCategories[$temporaryId]);
+        }
+
+        return $totalByCategories;
+    }
+
+    /**
+     * @param ICategory[] $categories
+     */
+    private static function getCampIncomeCategoryId(array $categories, ParticipantType $type) : ?int
+    {
+        foreach ($categories as $c) {
+            if ($c instanceof CampCategory && $c->getParticipantType() !== null && $c->getParticipantType()->equals($type)) {
+                return $c->getId();
+            }
+        }
+        throw new InvalidArgumentException(sprintf('Seznam táborových kategorií neobsahuje požadový typ "%s".', $type->getValue()));
     }
 }

--- a/app/model/Cashbook/ReadModel/QueryHandlers/CategoryListQueryHandler.php
+++ b/app/model/Cashbook/ReadModel/QueryHandlers/CategoryListQueryHandler.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Model\Cashbook\ReadModel\QueryHandlers;
 
 use Model\Cashbook\CashbookNotFound;
+use Model\Cashbook\ICategory;
 use Model\Cashbook\ReadModel\CategoryTotalsCalculator;
 use Model\Cashbook\ReadModel\Queries\CategoryListQuery;
 use Model\Cashbook\Repositories\CategoryRepository;
 use Model\Cashbook\Repositories\ICashbookRepository;
 use Model\DTO\Cashbook\Category;
 use Model\Utils\MoneyFactory;
+use function array_filter;
+use function in_array;
 
 class CategoryListQueryHandler
 {
@@ -39,7 +42,12 @@ class CategoryListQueryHandler
 
         $calculator = new CategoryTotalsCalculator();
 
-        $totalByCategories = $calculator->calculate($cashbook);
+        $totalByCategories = $calculator->calculate($cashbook, $categories);
+
+        // filter out camp refund categories
+        $categories = array_filter($categories, function (ICategory $category) {
+            return ! in_array($category->getId(), [ICategory::CATEGORY_REFUND_CHILD_ID, ICategory::CATEGORY_REFUND_ADULT_ID]);
+        });
 
         $categoriesById = [];
         foreach ($categories as $category) {

--- a/app/model/Export/ExportService.php
+++ b/app/model/Export/ExportService.php
@@ -38,7 +38,6 @@ use Model\Services\TemplateFactory;
 use Model\Utils\MoneyFactory;
 use function array_column;
 use function array_filter;
-use function array_key_exists;
 use function array_sum;
 use function array_values;
 use function assert;
@@ -240,13 +239,6 @@ class ExportService
             }
         }
 
-        $refund = null;
-        if (array_key_exists(ICategory::CATEGORY_REFUND_ID, $categories)) {
-            $refund = $categories[ICategory::CATEGORY_REFUND_ID];
-            assert($refund instanceof Category);
-            $total['income'] = $total['income']->subtract($refund->getTotal());
-        }
-
         $stats = $this->queryBus->handle(new CampParticipantStatisticsQuery(new SkautisCampId($skautisCampId)));
         assert($stats instanceof Statistics);
 
@@ -264,7 +256,6 @@ class ExportService
             'virtualTotalExpense' => $total['virtualExpense'],
             'functions' => $this->queryBus->handle(new CampFunctions(new SkautisCampId($skautisCampId))),
             'areTotalsConsistentWithSkautis' => $areTotalsConsistentWithSkautis,
-            'refund' => $refund,
         ]);
     }
 }

--- a/app/model/Export/templates/campReport.latte
+++ b/app/model/Export/templates/campReport.latte
@@ -75,9 +75,6 @@ table {
             {ifset $incomeCategories[$i]}
                 <td>{$incomeCategories[$i]->name}</td>
                 <td>{$incomeCategories[$i]->total|price}</td>
-            {elseif $i == count($incomeCategories)}
-                <td>{$refund->getName()}</td>
-                <td>- {$refund->getTotal()|price}</td>
             {else}
                 <td></td>
                 <td></td>

--- a/migrations/2020/Version20200112173514.php
+++ b/migrations/2020/Version20200112173514.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20200112173514 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Rozdělení vratek u tábora na dětské a dospělé';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $this->addSql(<<<SQL
+            INSERT INTO `ac_chitsCategory` (`id`, `label`, `short`, `type`, `virtual`, `orderby`, `deleted`) VALUES
+            (21, 'Vratka úč. poplatku - dítě',	'vrc',  'out', 1, 100, 0),
+            (22, 'Vratka úč. poplatku - dospělý','vra', 'out', 1, 100, 0);
+        SQL);
+        $this->addSql('INSERT INTO `ac_chitsCategory_object` (`categoryId`, `objectTypeId`) VALUES (21,	\'camp\'), (22,	\'camp\');');
+
+        $ids = $this->connection->fetchAll(<<<SQL
+                SELECT i.id
+                FROM `ac_chits_item` i
+                left join ac_chit_to_item ci ON i.id = ci.item_id
+                left join ac_chits c ON c.id = ci.chit_id
+                LEFT JOIN ac_object o ON c.eventId = o.id
+                WHERE `category` = '20' AND type ='camp'
+        SQL);
+
+        foreach ($ids as $row) {
+            $this->connection->update(
+                'ac_chits_item',
+                ['category' => 21],
+                ['id' => $row['id']]
+            );
+        }
+
+        $this->addSql('DELETE FROM `ac_chitsCategory_object` WHERE `categoryId` = \'20\' AND `objectTypeId` = \'camp\';');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->addSql('INSERT INTO `ac_chitsCategory_object` (`categoryId`, `objectTypeId`) VALUES (20, \'camp\');');
+        $ids = $this->connection->fetchAll(<<<SQL
+                SELECT i.id
+                FROM `ac_chits_item` i
+                left join ac_chit_to_item ci ON i.id = ci.item_id
+                left join ac_chits c ON c.id = ci.chit_id
+                LEFT JOIN ac_object o ON c.eventId = o.id
+                WHERE (`category` = '21' OR `category` = '22') AND type ='camp'
+        SQL);
+
+        foreach ($ids as $row) {
+            $this->connection->update(
+                'ac_chits_item',
+                ['category' => 20],
+                ['id' => $row['id']]
+            );
+        }
+        $this->addSql('DELETE FROM `ac_chitsCategory_object` WHERE `categoryId` IN (\'21\', \'22\');');
+        $this->addSql('DELETE FROM `ac_chitsCategory` WHERE `id` IN (\'21\', \'22\');');
+    }
+}

--- a/tests/unit/Cashbook/ReadModel/CategoryTotalsCalculatorTest.php
+++ b/tests/unit/Cashbook/ReadModel/CategoryTotalsCalculatorTest.php
@@ -6,18 +6,25 @@ namespace Model\Cashbook\ReadModel\QueryHandlers;
 
 use Codeception\Test\Unit;
 use Mockery as m;
+use Model\Cashbook\CampCategory;
 use Model\Cashbook\Cashbook;
 use Model\Cashbook\ICategory;
+use Model\Cashbook\Operation;
+use Model\Cashbook\ParticipantType;
 use Model\Cashbook\ReadModel\CategoryTotalsCalculator;
+use Model\Utils\MoneyFactory;
 use function array_key_exists;
 
 final class CategoryTotalsCalculatorTest extends Unit
 {
+    private const CATEGORY_INCOME_CHILD_ID = 8888;
+    private const CATEGORY_INCOME_ADULT_ID = 9999;
+
     public function testEventCalculation() : void
     {
-        $cashbook   = $this->mockCashbook(Cashbook\CashbookType::get(Cashbook\CashbookType::EVENT));
+        $cashbook   = $this->mockEventCashbook();
         $calculator = new CategoryTotalsCalculator();
-        $totals     = $calculator->calculate($cashbook);
+        $totals     = $calculator->calculate($cashbook, []);
 
         $this->assertSame(400.0, $totals[ICategory::CATEGORY_PARTICIPANT_INCOME_ID]);
         $this->assertFalse(array_key_exists(ICategory::CATEGORY_HPD_ID, $totals));
@@ -27,17 +34,21 @@ final class CategoryTotalsCalculatorTest extends Unit
 
     public function testCampCalculation() : void
     {
-        $cashbook   = $this->mockCashbook(Cashbook\CashbookType::get(Cashbook\CashbookType::CAMP));
+        $cashbook   = $this->mockCampCashbook();
         $calculator = new CategoryTotalsCalculator();
-        $totals     = $calculator->calculate($cashbook);
 
-        $this->assertSame(55.0, $totals[ICategory::CATEGORY_PARTICIPANT_INCOME_ID]);
-        $this->assertSame(500.0, $totals[ICategory::CATEGORY_HPD_ID]);
-        $this->assertSame(155.0, $totals[ICategory::CATEGORY_REFUND_ID]);
+        $categories = [
+            new CampCategory(self::CATEGORY_INCOME_CHILD_ID, Operation::INCOME(), 'Příjmy od dětí a roverů', MoneyFactory::zero(), ParticipantType::CHILD()),
+            new CampCategory(self::CATEGORY_INCOME_ADULT_ID, Operation::INCOME(), 'Příjmy od dospělých', MoneyFactory::zero(), ParticipantType::ADULT()),
+        ];
+        $totals     = $calculator->calculate($cashbook, $categories);
+
+        $this->assertSame(250.0, $totals[self::CATEGORY_INCOME_CHILD_ID]);
+        $this->assertSame(100.0, $totals[self::CATEGORY_INCOME_ADULT_ID]);
         $this->assertSame(200.0, $totals[2]);
     }
 
-    private function mockCashbook(Cashbook\CashbookType $type) : Cashbook
+    private function mockEventCashbook() : Cashbook
     {
         $cashbook = m::mock(Cashbook::class);
 
@@ -49,7 +60,25 @@ final class CategoryTotalsCalculatorTest extends Unit
                 ICategory::CATEGORY_PARTICIPANT_INCOME_ID => 55.0,
             ]);
         $cashbook->shouldReceive('getType')
-            ->andReturn($type);
+            ->andReturn(Cashbook\CashbookType::get(Cashbook\CashbookType::EVENT));
+
+        return $cashbook;
+    }
+
+    private function mockCampCashbook() : Cashbook
+    {
+        $cashbook = m::mock(Cashbook::class);
+
+        $cashbook->shouldReceive('getCategoryTotals')
+            ->andReturn([
+                2 => 200.0,
+                self::CATEGORY_INCOME_CHILD_ID => 300.0,
+                self::CATEGORY_INCOME_ADULT_ID => 123.0,
+                ICategory::CATEGORY_REFUND_CHILD_ID => 50.0,
+                ICategory::CATEGORY_REFUND_ADULT_ID => 23.0,
+            ]);
+        $cashbook->shouldReceive('getType')
+            ->andReturn(Cashbook\CashbookType::get(Cashbook\CashbookType::CAMP));
 
         return $cashbook;
     }


### PR DESCRIPTION
close #982

Historické táborové vratky jsou přesunuty jako dětské v rámci migrace.