### PR TITLE
Oprava JS na "velkých stránkách"

### DIFF
--- a/frontend/ts/ajax.ts
+++ b/frontend/ts/ajax.ts
@@ -29,5 +29,11 @@ export default function (): void {
 
     naja.formsHandler.netteForms = netteForms;
 
+    // Prevents NS_ERROR_ILLEGAL_VALUE on large pages in Firefox
+    (naja as any).historyHandler.historyAdapter = {
+        replaceState: () => {},
+        pushState: () => {},
+    };
+
     naja.initialize({history: false});
 }


### PR DESCRIPTION
Na velkých* stránkách se nepodaří Naja uložit stránku přes History API, které jinak stejně nepoužíváme.

To vede k chybě, kvůli které se nezpracuje nic dalšího, takže na stránce například nejsou ikony.

\* velká stránka je např. detail skupiny s 64+ platbami. U registrací a plesu jsem na to teď několikrát narazil. Menší stránky jsou ok.