### PR TITLE
Automatické dohledávání entit z agregátu v testech

### DIFF
--- a/tests/integration/Cashbook/CashbookIntegrationTest.php
+++ b/tests/integration/Cashbook/CashbookIntegrationTest.php
@@ -10,7 +10,6 @@ use IntegrationTest;
 use Model\Cashbook\Cashbook\Amount;
 use Model\Cashbook\Cashbook\CashbookId;
 use Model\Cashbook\Cashbook\CashbookType;
-use Model\Cashbook\Cashbook\Chit;
 use Model\Cashbook\Cashbook\ChitBody;
 use Model\Cashbook\Cashbook\ChitItem;
 use Model\Cashbook\Cashbook\ChitNumber;
@@ -31,13 +30,9 @@ class CashbookIntegrationTest extends IntegrationTest
     /**
      * @return string[]
      */
-    public function getTestedEntites() : array
+    public function getTestedAggregateRoots() : array
     {
-        return [
-            Cashbook::class,
-            Chit::class,
-            ChitItem::class,
-        ];
+        return [Cashbook::class];
     }
 
     public function testLockingLockedChitDoesNothing() : void

--- a/tests/integration/Cashbook/Handlers/MoveChitsToDifferentCashbookHandlerTest.php
+++ b/tests/integration/Cashbook/Handlers/MoveChitsToDifferentCashbookHandlerTest.php
@@ -60,13 +60,9 @@ final class MoveChitsToDifferentCashbookHandlerTest extends CommandHandlerTest
     /**
      * @return string[]
      */
-    protected function getTestedEntites() : array
+    protected function getTestedAggregateRoots() : array
     {
-        return [
-            Cashbook::class,
-            Cashbook\Chit::class,
-            Cashbook\ChitItem::class,
-        ];
+        return [Cashbook::class];
     }
 
     protected function _before() : void

--- a/tests/integration/Cashbook/Handlers/Unit/CreateCashbookHandlerTest.php
+++ b/tests/integration/Cashbook/Handlers/Unit/CreateCashbookHandlerTest.php
@@ -30,13 +30,11 @@ final class CreateCashbookHandlerTest extends CommandHandlerTest
     /**
      * @return string[]
      */
-    protected function getTestedEntites() : array
+    protected function getTestedAggregateRoots() : array
     {
         return [
             Unit::class,
-            Unit\Cashbook::class,
             Cashbook::class,
-            Cashbook\Chit::class,
         ];
     }
 

--- a/tests/integration/Cashbook/Handlers/Unit/CreateUnitHandlerTest.php
+++ b/tests/integration/Cashbook/Handlers/Unit/CreateUnitHandlerTest.php
@@ -30,13 +30,11 @@ final class CreateUnitHandlerTest extends CommandHandlerTest
     /**
      * @return string[]
      */
-    protected function getTestedEntites() : array
+    protected function getTestedAggregateRoots() : array
     {
         return [
             Unit::class,
-            Unit\Cashbook::class,
             Cashbook::class,
-            Cashbook\Chit::class,
         ];
     }
 

--- a/tests/integration/Cashbook/ReadModel/QueryHandlers/ChitListQueryHandlerTest.php
+++ b/tests/integration/Cashbook/ReadModel/QueryHandlers/ChitListQueryHandlerTest.php
@@ -24,13 +24,9 @@ class ChitListQueryHandlerTest extends IntegrationTest
     /**
      * @return string[]
      */
-    protected function getTestedEntites() : array
+    protected function getTestedAggregateRoots() : array
     {
-        return [
-            Cashbook::class,
-            Cashbook\Chit::class,
-            Cashbook\ChitItem::class,
-        ];
+        return [Cashbook::class];
     }
 
     protected function _before() : void

--- a/tests/integration/Infrastructure/Repositories/Budget/CategoryRepositoryTest.php
+++ b/tests/integration/Infrastructure/Repositories/Budget/CategoryRepositoryTest.php
@@ -23,11 +23,9 @@ class CategoryRepositoryTest extends IntegrationTest
     /**
      * @return string[]
      */
-    public function getTestedEntites() : array
+    public function getTestedAggregateRoots() : array
     {
-        return [
-            Category::class,
-        ];
+        return [Category::class];
     }
 
     public function testSaveRootCategory() : void

--- a/tests/integration/Infrastructure/Repositories/Cashbook/CashbookRepositoryTest.php
+++ b/tests/integration/Infrastructure/Repositories/Cashbook/CashbookRepositoryTest.php
@@ -36,13 +36,9 @@ class CashbookRepositoryTest extends IntegrationTest
     /**
      * @return string[]
      */
-    public function getTestedEntites() : array
+    public function getTestedAggregateRoots() : array
     {
-        return [
-            Cashbook::class,
-            Cashbook\Chit::class,
-            Cashbook\ChitItem::class,
-        ];
+        return [Cashbook::class];
     }
 
     public function testFindEmptyCashbook() : void

--- a/tests/integration/Infrastructure/Repositories/Cashbook/StaticCategoryRepositoryTest.php
+++ b/tests/integration/Infrastructure/Repositories/Cashbook/StaticCategoryRepositoryTest.php
@@ -29,12 +29,9 @@ class StaticCategoryRepositoryTest extends IntegrationTest
     /**
      * @return string[]
      */
-    protected function getTestedEntites() : array
+    protected function getTestedAggregateRoots() : array
     {
-        return [
-            Category::class,
-            Category\ObjectType::class,
-        ];
+        return [Category::class];
     }
 
     public function testFindByObjectType() : void

--- a/tests/integration/Infrastructure/Repositories/Cashbook/UnitRepositoryTest.php
+++ b/tests/integration/Infrastructure/Repositories/Cashbook/UnitRepositoryTest.php
@@ -31,12 +31,9 @@ final class UnitRepositoryTest extends IntegrationTest
     /**
      * @return string[]
      */
-    protected function getTestedEntites() : array
+    protected function getTestedAggregateRoots() : array
     {
-        return [
-            Unit::class,
-            Unit\Cashbook::class,
-        ];
+        return [Unit::class];
     }
 
     public function testSaveAddsRowsToDatabase() : void

--- a/tests/integration/Infrastructure/Repositories/Logger/LogEntryRepositoryTest.php
+++ b/tests/integration/Infrastructure/Repositories/Logger/LogEntryRepositoryTest.php
@@ -21,11 +21,9 @@ final class LogEntryRepositoryTest extends IntegrationTest
     /**
      * @return string[]
      */
-    public function getTestedEntites() : array
+    public function getTestedAggregateRoots() : array
     {
-        return [
-            LogEntry::class,
-        ];
+        return [LogEntry::class];
     }
 
     protected function _before() : void

--- a/tests/integration/Infrastructure/Repositories/Payment/BankAccountRepositoryTest.php
+++ b/tests/integration/Infrastructure/Repositories/Payment/BankAccountRepositoryTest.php
@@ -20,11 +20,9 @@ class BankAccountRepositoryTest extends IntegrationTest
     /**
      * @return string[]
      */
-    public function getTestedEntites() : array
+    public function getTestedAggregateRoots() : array
     {
-        return [
-            BankAccount::class,
-        ];
+        return [BankAccount::class];
     }
 
     protected function _before() : void

--- a/tests/integration/Infrastructure/Repositories/Payment/GroupRepositoryTest.php
+++ b/tests/integration/Infrastructure/Repositories/Payment/GroupRepositoryTest.php
@@ -43,13 +43,9 @@ class GroupRepositoryTest extends IntegrationTest
     /**
      * @return string[]
      */
-    public function getTestedEntites() : array
+    public function getTestedAggregateRoots() : array
     {
-        return [
-            Group::class,
-            Group\Email::class,
-            Group\Unit::class,
-        ];
+        return [Group::class];
     }
 
     protected function _before() : void

--- a/tests/integration/Infrastructure/Repositories/Payment/MailCredentialsRepositoryTest.php
+++ b/tests/integration/Infrastructure/Repositories/Payment/MailCredentialsRepositoryTest.php
@@ -24,11 +24,9 @@ class MailCredentialsRepositoryTest extends IntegrationTest
     /**
      * @return string[]
      */
-    public function getTestedEntites() : array
+    public function getTestedAggregateRoots() : array
     {
-        return [
-            MailCredentials::class,
-        ];
+        return [MailCredentials::class];
     }
 
     protected function _before() : void

--- a/tests/integration/Infrastructure/Repositories/Payment/PaymentRepositoryTest.php
+++ b/tests/integration/Infrastructure/Repositories/Payment/PaymentRepositoryTest.php
@@ -38,7 +38,7 @@ class PaymentRepositoryTest extends IntegrationTest
     /**
      * @return string[]
      */
-    public function getTestedEntites() : array
+    public function getTestedAggregateRoots() : array
     {
         return [
             Payment::class,

--- a/tests/integration/Infrastructure/Repositories/Travel/CommandRepositoryTest.php
+++ b/tests/integration/Infrastructure/Repositories/Travel/CommandRepositoryTest.php
@@ -9,7 +9,6 @@ use DateTimeImmutable;
 use Doctrine\ORM\EntityManager;
 use IntegrationTest;
 use Model\Travel\Command;
-use Model\Travel\Travel\Type;
 use Model\Travel\Vehicle;
 use Model\Utils\MoneyFactory;
 use function array_map;
@@ -64,13 +63,11 @@ class CommandRepositoryTest extends IntegrationTest
     /**
      * @return string[]
      */
-    public function getTestedEntites() : array
+    public function getTestedAggregateRoots() : array
     {
         return [
             Command::class,
-            Command\Travel::class,
             Vehicle::class, // right now there is direct reference between the two
-            Type::class,
         ];
     }
 

--- a/tests/integration/Infrastructure/Repositories/Travel/ContractRepositoryTest.php
+++ b/tests/integration/Infrastructure/Repositories/Travel/ContractRepositoryTest.php
@@ -34,12 +34,9 @@ final class ContractRepositoryTest extends IntegrationTest
     /**
      * @return string[]
      */
-    protected function getTestedEntites() : array
+    protected function getTestedAggregateRoots() : array
     {
-        return [
-            Contract::class,
-            Contract\Passenger::class,
-        ];
+        return [Contract::class];
     }
 
     public function testFindReturnsCorrectlyHydratedAggregate() : void

--- a/tests/integration/Infrastructure/Repositories/Travel/VehicleRepositoryTest.php
+++ b/tests/integration/Infrastructure/Repositories/Travel/VehicleRepositoryTest.php
@@ -23,12 +23,9 @@ class VehicleRepositoryTest extends IntegrationTest
     /**
      * @return string[]
      */
-    public function getTestedEntites() : array
+    public function getTestedAggregateRoots() : array
     {
-        return [
-            Vehicle::class,
-            Vehicle\RoadworthyScan::class,
-        ];
+        return [Vehicle::class];
     }
 
     protected function _before() : void

--- a/tests/integration/Payment/BankAccountServiceTest.php
+++ b/tests/integration/Payment/BankAccountServiceTest.php
@@ -43,13 +43,11 @@ class BankAccountServiceTest extends IntegrationTest
     /**
      * @return string[]
      */
-    public function getTestedEntites() : array
+    public function getTestedAggregateRoots() : array
     {
         return [
             BankAccount::class,
             Group::class,
-            Group\Email::class,
-            Group\Unit::class,
         ];
     }
 

--- a/tests/integration/Payment/BankServiceTest.php
+++ b/tests/integration/Payment/BankServiceTest.php
@@ -60,13 +60,11 @@ class BankServiceTest extends IntegrationTest
     /**
      * @return string[]
      */
-    protected function getTestedEntites() : array
+    protected function getTestedAggregateRoots() : array
     {
         return [
             BankAccount::class,
             Group::class,
-            Group\Email::class,
-            Group\Unit::class,
             Payment::class,
         ];
     }

--- a/tests/integration/Payment/Handlers/MailCredentials/CreateMailCredentialsHandlerTest.php
+++ b/tests/integration/Payment/Handlers/MailCredentials/CreateMailCredentialsHandlerTest.php
@@ -28,11 +28,9 @@ class CreateMailCredentialsHandlerTest extends CommandHandlerTest
     /**
      * @return string[]
      */
-    public function getTestedEntites() : array
+    public function getTestedAggregateRoots() : array
     {
-        return [
-            MailCredentials::class,
-        ];
+        return [MailCredentials::class];
     }
 
     public function testRecordToDatabaseIsAdded() : void

--- a/tests/integration/Payment/Handlers/MailCredentials/RemoveMailCredentialsHandlerTest.php
+++ b/tests/integration/Payment/Handlers/MailCredentials/RemoveMailCredentialsHandlerTest.php
@@ -20,7 +20,7 @@ class RemoveMailCredentialsHandlerTest extends CommandHandlerTest
     /**
      * @return string[]
      */
-    public function getTestedEntites() : array
+    public function getTestedAggregateRoots() : array
     {
         return [
             MailCredentials::class,

--- a/tests/integration/Payment/ReadModel/QueryHandlers/CountGroupsWithBankAccountQueryHandlerTest.php
+++ b/tests/integration/Payment/ReadModel/QueryHandlers/CountGroupsWithBankAccountQueryHandlerTest.php
@@ -14,7 +14,7 @@ final class CountGroupsWithBankAccountQueryHandlerTest extends IntegrationTest
     /**
      * @return string[]
      */
-    protected function getTestedEntites() : array
+    protected function getTestedAggregateRoots() : array
     {
         return [Group::class];
     }

--- a/tests/integration/Payment/ReadModel/QueryHandlers/PairedPaymentsQueryHandlerTest.php
+++ b/tests/integration/Payment/ReadModel/QueryHandlers/PairedPaymentsQueryHandlerTest.php
@@ -16,7 +16,7 @@ final class PairedPaymentsQueryHandlerTest extends IntegrationTest
     /**
      * @return string[]
      */
-    protected function getTestedEntites() : array
+    protected function getTestedAggregateRoots() : array
     {
         return [
             Payment::class,

--- a/tests/integration/Payment/UseCases/LastPairingInvalidationTest.php
+++ b/tests/integration/Payment/UseCases/LastPairingInvalidationTest.php
@@ -30,13 +30,11 @@ final class LastPairingInvalidationTest extends IntegrationTest
     /**
      * @return string[]
      */
-    public function getTestedEntites() : array
+    public function getTestedAggregateRoots() : array
     {
         return [
             BankAccount::class,
             Group::class,
-            Group\Unit::class,
-            Group\Email::class,
             Payment::class,
         ];
     }

--- a/tests/integration/Payment/UseCases/PaymentCompletedEmailTest.php
+++ b/tests/integration/Payment/UseCases/PaymentCompletedEmailTest.php
@@ -36,12 +36,10 @@ class PaymentCompletedEmailTest extends IntegrationTest
     /**
      * @return string[]
      */
-    protected function getTestedEntites() : array
+    protected function getTestedAggregateRoots() : array
     {
         return [
             Group::class,
-            Group\Email::class,
-            Group\Unit::class,
             Payment::class,
             MailCredentials::class,
         ];

--- a/tests/integration/Payment/UseCases/RemoveGroupTest.php
+++ b/tests/integration/Payment/UseCases/RemoveGroupTest.php
@@ -31,12 +31,10 @@ final class RemoveGroupTest extends IntegrationTest
     /**
      * @return string[]
      */
-    protected function getTestedEntites() : array
+    protected function getTestedAggregateRoots() : array
     {
         return [
             Group::class,
-            Group\Email::class,
-            Group\Unit::class,
             Payment::class,
         ];
     }

--- a/tests/integration/Payment/UseCases/RemoveMailCredentialsTest.php
+++ b/tests/integration/Payment/UseCases/RemoveMailCredentialsTest.php
@@ -31,13 +31,11 @@ final class RemoveMailCredentialsTest extends IntegrationTest
     /**
      * @return string[]
      */
-    protected function getTestedEntites() : array
+    protected function getTestedAggregateRoots() : array
     {
         return [
             MailCredentials::class,
             Group::class,
-            Group\Email::class,
-            Group\Unit::class,
         ];
     }
 

--- a/tests/integration/PaymentServiceTest.php
+++ b/tests/integration/PaymentServiceTest.php
@@ -27,12 +27,10 @@ class PaymentServiceTest extends IntegrationTest
     /**
      * @return string[]
      */
-    public function getTestedEntites() : array
+    public function getTestedAggregateRoots() : array
     {
         return [
             Group::class,
-            Group\Email::class,
-            Group\Unit::class,
             Payment::class,
         ];
     }


### PR DESCRIPTION
Momentálně přidání nové entity do agregátu znamená to, že je ve všech integračních testech, kde se s daným agregátem nějak pracuje, potřeba doplnit třídu entity do `getTestedEntites()`, aby se pro ně v testech vytvořily tabulky. To je dost opruz a jde to vyřešit jednodušeji.

Proto jsem z jiného projektu převzal řešení, kdy stačí vyjmenovat AR/hlavní entitu a zbytek entit se automaticky dohledá.