### PR TITLE
Oprava kontroly, zda lze zrušit akci

### DIFF
--- a/app/AccountancyModule/EventModule/presenters/DefaultPresenter.php
+++ b/app/AccountancyModule/EventModule/presenters/DefaultPresenter.php
@@ -46,7 +46,7 @@ class DefaultPresenter extends BasePresenter
 
     public function handleCancel(int $aid) : void
     {
-        if (! $this->authorizator->isAllowed(EventResource::DELETE, $aid)) {
+        if (! $this->authorizator->isAllowed(EventResource::CANCEL, $aid)) {
             $this->flashMessage('Nemáte právo na zrušení akce.', 'danger');
             $this->redirect('this');
         }
@@ -119,7 +119,7 @@ class DefaultPresenter extends BasePresenter
             ->setTitle('Zrušit akci')
             ->setIcon('far fa-trash-alt')
             ->setRenderCondition(function (EventListItem $event) {
-                return $this->authorizator->isAllowed(EventResource::DELETE, $event->getId());
+                return $this->authorizator->isAllowed(EventResource::CANCEL, $event->getId());
             });
 
         return $grid;

--- a/app/model/Auth/Resources/Event.php
+++ b/app/model/Auth/Resources/Event.php
@@ -14,7 +14,7 @@ final class Event
 
     public const UPDATE_FUNCTION = [self::class, 'EV_EventGeneral_UPDATE_Function'];
     public const UPDATE          = [self::class, 'EV_EventGeneral_UPDATE'];
-    public const DELETE          = [self::class, 'EV_EventGeneral_DELETE'];
+    public const CANCEL          = [self::class, 'EV_EventGeneral_UPDATE_Cancel'];
     public const ACCESS_DETAIL   = [self::class, 'EV_EventGeneral_DETAIL'];
 
     public const ACCESS_PARTICIPANTS = [self::class, 'EV_ParticipantGeneral_ALL_EventGeneral'];


### PR DESCRIPTION
Opravuje https://sentry.io/organizations/skautske-hospodareni-of/issues/1465067836/?project=1328535&query=is%3Aunresolved

Checkovali jsme možnost smazat akci (což neděláme nikde), nikoliv zrušit akci. Takže šlo volat zrušení na už zrušených akcích.