### PR TITLE
Sjednocení mapování a databáze

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,3 +124,30 @@ jobs:
               run: tar -xzf workdir.tar.gz
             - run: mv app/config/config.ci.local.neon app/config/config.local.neon
             - run: php www/index.php app:lint-latte
+
+    validate-mapping:
+        name: "Validate mapping against migrations"
+        runs-on: ubuntu-18.04
+        container:
+            image: fmasa/lebeda:7.4
+        needs: workdir
+        services:
+            mysql-test:
+                image: mysql:5.7
+                env:
+                    MYSQL_ROOT_PASSWORD: 'root'
+                    MYSQL_DATABASE: hskauting
+                options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+        env:
+            DEVELOPMENT_MACHINE: true
+        steps:
+            - name: Download workdir
+              uses: actions/download-artifact@v1
+              with:
+                  name: workdir
+                  path: .
+            - name: Extract workdir
+              run: tar -xzf workdir.tar.gz
+            - run: mv app/config/config.ci.local.neon app/config/config.local.neon
+            - run: php www/index.php migrations:migrate --no-interaction
+            - run: "! php www/index.php migrations:diff && php www/index.php migrations:diff --allow-empty-diff"

--- a/app/config/model/doctrine.neon
+++ b/app/config/model/doctrine.neon
@@ -13,6 +13,9 @@ doctrine:
     user: %database.user%
     password: %database.password%
     dbname: %database.name%
+
+    schemaFilter: '~^(?!ac_object)~'
+
     metadata:
         Model\Cashbook: %domainModelDir%/Cashbook
         Model\Logger: %domainModelDir%/Logger

--- a/app/config/model/doctrine.neon
+++ b/app/config/model/doctrine.neon
@@ -59,3 +59,7 @@ decorator:
 
     Symfony\Component\Console\Helper\Helper:
         tags: [ kdyby.console.helper ]
+
+    Doctrine\Migrations\Configuration\Configuration:
+        setup:
+            - setCheckDatabasePlatform(false)

--- a/app/model/Budget/Category.php
+++ b/app/model/Budget/Category.php
@@ -11,7 +11,10 @@ use Model\Cashbook\Operation;
 
 /**
  * @ORM\Entity()
- * @ORM\Table(name="ac_unit_budget_category")
+ * @ORM\Table(
+ *     name="ac_unit_budget_category",
+ *     indexes={@ORM\Index(name="objectId_year", columns={"unit_id", "year"})}
+ * )
  */
 class Category
 {

--- a/app/model/Budget/Category.php
+++ b/app/model/Budget/Category.php
@@ -39,7 +39,7 @@ class Category
     private $label;
 
     /**
-     * @ORM\Column(type="string_enum", options={"default"="out"})
+     * @ORM\Column(type="string_enum")
      *
      * @var Operation
      * @EnumAnnotation(class=\Model\Cashbook\Operation::class)

--- a/app/model/Cashbook/Cashbook/Chit.php
+++ b/app/model/Cashbook/Cashbook/Chit.php
@@ -56,9 +56,9 @@ class Chit
      * @ORM\ManyToMany(targetEntity=ChitItem::class, cascade={"persist", "remove"}, orphanRemoval=true)
      * @ORM\JoinTable(
      *     name="ac_chit_to_item",
-     *     joinColumns={@ORM\JoinColumn(name="chit_id", referencedColumnName="id")},
+     *     joinColumns={@ORM\JoinColumn(name="chit_id", referencedColumnName="id", onDelete="CASCADE")},
      *     inverseJoinColumns={
-     *         @ORM\JoinColumn(name="item_id", referencedColumnName="id", unique=true)
+     *         @ORM\JoinColumn(name="item_id", referencedColumnName="id", unique=true, onDelete="CASCADE")
      *     }
      * )
      *

--- a/app/model/Cashbook/Category.php
+++ b/app/model/Cashbook/Category.php
@@ -10,7 +10,13 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity()
- * @ORM\Table(name="ac_chitsCategory")
+ * @ORM\Table(
+ *     name="ac_chitsCategory",
+ *     indexes={
+ *          @ORM\Index(name="deleted", columns={"deleted"}),
+ *          @ORM\Index(name="orderby", columns={"orderby"}),
+ *     }
+ * )
  * @ORM\Cache()
  */
 class Category implements ICategory
@@ -34,7 +40,7 @@ class Category implements ICategory
     private $name;
 
     /**
-     * @ORM\Column(type="string", name="short", length=64)
+     * @ORM\Column(type="string", name="short", length=64, unique=true)
      *
      * @var string
      */

--- a/app/model/Cashbook/Category/ObjectType.php
+++ b/app/model/Cashbook/Category/ObjectType.php
@@ -11,7 +11,10 @@ use Model\Cashbook\ObjectType as ObjectTypeEnum;
 
 /**
  * @ORM\Entity()
- * @ORM\Table(name="ac_chitsCategory_object")
+ * @ORM\Table(
+ *     name="ac_chitsCategory_object",
+ *     indexes={@ORM\Index(name="objectTypeId", columns={"objectTypeId"})}
+ * )
  */
 class ObjectType
 {

--- a/app/model/Infrastructure/Types/MoneyType.php
+++ b/app/model/Infrastructure/Types/MoneyType.php
@@ -5,19 +5,13 @@ declare(strict_types=1);
 namespace Model\Infrastructure\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\DecimalType;
+use Doctrine\DBAL\Types\IntegerType;
 use InvalidArgumentException;
-use Money\Currency;
 use Money\Money;
-use function array_merge;
-use function bcdiv;
-use function bcmul;
 
-class MoneyType extends DecimalType
+class MoneyType extends IntegerType
 {
-    public const NAME      = 'money';
-    private const SUBUNITS = '100';
-    private const CURRENCY = 'CZK';
+    public const NAME = 'money';
 
     public function getName() : string
     {
@@ -29,9 +23,7 @@ class MoneyType extends DecimalType
      */
     public function convertToPHPValue($value, AbstractPlatform $platform) : Money
     {
-        $stringValue = parent::convertToPHPValue($value, $platform);
-
-        return new Money(bcmul($stringValue, self::SUBUNITS), new Currency(self::CURRENCY));
+        return Money::CZK(parent::convertToPHPValue($value, $platform));
     }
 
     /**
@@ -43,16 +35,6 @@ class MoneyType extends DecimalType
             throw new InvalidArgumentException('Only instances of ' . Money::class . 'allowed');
         }
 
-        return bcdiv($value->getAmount(), self::SUBUNITS, 2);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getSqlDeclaration(array $fieldDeclaration, AbstractPlatform $platform) : string
-    {
-        $fieldDeclaration = array_merge($fieldDeclaration, ['precision' => 8, 'scale' => 2]);
-
-        return parent::getSqlDeclaration($fieldDeclaration, $platform);
+        return $value->getAmount();
     }
 }

--- a/app/model/Logger/LogEntry.php
+++ b/app/model/Logger/LogEntry.php
@@ -11,7 +11,13 @@ use Model\Logger\Log\Type;
 
 /**
  * @ORM\Entity()
- * @ORM\Table(name="log")
+ * @ORM\Table(
+ *     name="log",
+ *     indexes={
+ *          @ORM\Index(name="unitId", columns={"unitId"}),
+ *          @ORM\Index(name="typeId", columns={"typeId"}),
+ *      }
+ * )
  */
 class LogEntry
 {

--- a/app/model/Participant/Payment.php
+++ b/app/model/Participant/Payment.php
@@ -54,7 +54,7 @@ class Payment
     private $repayment;
 
     /**
-     * @ORM\Column(type="string", name="isAccount", options={"default"="N", "comment"="placeno na účet?"})
+     * @ORM\Column(type="string", name="isAccount")
      *
      * @var string
      */

--- a/app/model/Participant/Payment.php
+++ b/app/model/Participant/Payment.php
@@ -13,7 +13,12 @@ use function in_array;
 
 /**
  * @ORM\Entity()
- * @ORM\Table(name="ac_participants")
+ * @ORM\Table(
+ *     name="ac_participants",
+ *     indexes={
+ *         @ORM\Index(name="actionId", columns={"event_id"}),
+ *     }
+ * )
  */
 class Payment
 {

--- a/migrations/2020/Version20200214111513.php
+++ b/migrations/2020/Version20200214111513.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20200214111513 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Remap enums as varchars';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE ac_participants CHANGE isAccount isAccount VARCHAR(255) NOT NULL COMMENT '(DC2Type:string_enum)'
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE ac_chitsCategory CHANGE type type VARCHAR(255) NOT NULL COMMENT '(DC2Type:string_enum)'
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE ac_unit_budget_category CHANGE type type VARCHAR(255) NOT NULL COMMENT '(DC2Type:string_enum)'
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE log CHANGE type type VARCHAR(255) NOT NULL COMMENT '(DC2Type:string_enum)'
+        SQL);
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->addSql("ALTER TABLE ac_participants CHANGE isAccount isAccount ENUM('N', 'Y') COLLATE utf8_czech_ci DEFAULT 'N' COMMENT 'placeno na účet?'");
+        $this->addSql("ALTER TABLE ac_chitsCategory CHANGE type type ENUM('in', 'out')  COLLATE utf8_czech_ci NOT NULL DEFAULT 'out'");
+        $this->addSql("ALTER TABLE ac_unit_budget_category CHANGE type type ENUM('in', 'out') COLLATE utf8_czech_ci NOT NULL DEFAULT 'out'");
+        $this->addSql("ALTER TABLE log CHANGE type type ENUM('object', 'payment') CHARACTER SET utf8 COLLATE utf8_czech_ci NOT NULL");
+    }
+}

--- a/migrations/2020/Version20200214114359.php
+++ b/migrations/2020/Version20200214114359.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20200214114359 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Unify mapping between Doctrine and ac_* tables';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $this->addSql('DROP INDEX participantId_event_type ON ac_participants');
+        $this->addSql(<<<SQL
+            ALTER TABLE ac_participants
+                CHANGE id id CHAR(36) NOT NULL COMMENT '(DC2Type:payment_id)',
+                CHANGE participantId participantId INT UNSIGNED NOT NULL,
+                CHANGE event_id event_id INT NOT NULL,
+                CHANGE payment payment NUMERIC(8, 2) NOT NULL COMMENT '(DC2Type:money)',
+                CHANGE repayment repayment NUMERIC(8, 2) NOT NULL COMMENT '(DC2Type:money)',
+                CHANGE isAccount isAccount VARCHAR(255) NOT NULL
+        SQL);
+        $this->addSql('ALTER TABLE ac_chitsCategory_object DROP FOREIGN KEY ac_chitsCategory_object_ibfk_1');
+        $this->addSql('ALTER TABLE ac_chitsCategory_object CHANGE objectTypeId objectTypeId VARCHAR(20) NOT NULL COMMENT \'(DC2Type:string_enum)\', ADD PRIMARY KEY (categoryId, objectTypeId)');
+        $this->addSql('ALTER TABLE ac_chitsCategory_object ADD CONSTRAINT FK_824C4F259C370B71 FOREIGN KEY (categoryId) REFERENCES ac_chitsCategory (id)');
+        $this->addSql('ALTER TABLE ac_chitsCategory_object RENAME INDEX categoryid TO IDX_824C4F259C370B71');
+        $this->addSql('ALTER TABLE ac_chits_item CHANGE price price DOUBLE PRECISION UNSIGNED NOT NULL');
+        $this->addSql('ALTER TABLE ac_chit_scan DROP FOREIGN KEY FK_FEC2BFD22AEA3AE4');
+        $this->addSql('ALTER TABLE ac_chit_scan CHANGE chit_id chit_id INT UNSIGNED DEFAULT NULL');
+
+        $this->addSql('DROP INDEX category ON ac_chits');
+        $this->addSql('ALTER TABLE ac_chit_to_item DROP FOREIGN KEY FK_2EA9AB792AEA3AE4');
+
+        $this->addSql(<<<'SQL'
+            ALTER TABLE ac_chits
+                DROP x_purpose,
+                DROP x_price,
+                DROP x_priceText,
+                DROP x_category,
+                DROP x_category_operation_type,
+                CHANGE id id INT UNSIGNED AUTO_INCREMENT NOT NULL,
+                CHANGE eventId eventId CHAR(36) DEFAULT NULL COMMENT '(DC2Type:cashbook_id)',
+                CHANGE num num VARCHAR(5) DEFAULT NULL COMMENT '(DC2Type:chit_number)',
+                CHANGE date date DATE NOT NULL COMMENT '(DC2Type:chronos_date)',
+                CHANGE recipient recipient VARCHAR(64) DEFAULT NULL COMMENT '(DC2Type:recipient)',
+                CHANGE payment_method payment_method VARCHAR(13) NOT NULL COMMENT '(DC2Type:string_enum)'
+        SQL);
+
+        $this->addSql('ALTER TABLE ac_chit_scan ADD CONSTRAINT FK_FEC2BFD22AEA3AE4 FOREIGN KEY (chit_id) REFERENCES ac_chits (id)');
+        $this->addSql('ALTER TABLE ac_chits ADD CONSTRAINT FK_DBBC2DBC2B2EBB6C FOREIGN KEY (eventId) REFERENCES ac_cashbook (id)');
+        $this->addSql('ALTER TABLE ac_chits RENAME INDEX eventid TO IDX_DBBC2DBC2B2EBB6C');
+        $this->addSql('ALTER TABLE ac_chit_to_item DROP FOREIGN KEY FK_2EA9AB79126F525E');
+        $this->addSql('ALTER TABLE ac_chit_to_item CHANGE chit_id chit_id INT UNSIGNED NOT NULL');
+        $this->addSql('ALTER TABLE ac_chit_to_item ADD CONSTRAINT FK_2EA9AB79126F525E FOREIGN KEY (item_id) REFERENCES ac_chits_item (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE ac_chit_to_item ADD CONSTRAINT FK_2EA9AB792AEA3AE4 FOREIGN KEY (chit_id) REFERENCES ac_chits (id)  ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE ac_chits DROP FOREIGN KEY FK_DBBC2DBC2B2EBB6C');
+        $this->addSql('ALTER TABLE ac_cashbook CHANGE id id CHAR(36) NOT NULL COMMENT \'(DC2Type:cashbook_id)\'');
+        $this->addSql('ALTER TABLE ac_chits ADD CONSTRAINT FK_DBBC2DBC2B2EBB6C FOREIGN KEY (eventId) references ac_cashbook (id)');
+
+        $this->addSql('ALTER TABLE ac_chitsCategory RENAME INDEX short TO UNIQ_43247D658F2890A2');
+        $this->addSql('ALTER TABLE ac_unit_budget_category DROP FOREIGN KEY ac_unit_budget_category_ibfk_4');
+        $this->addSql('ALTER TABLE ac_unit_budget_category DROP deleted');
+        $this->addSql('ALTER TABLE ac_unit_budget_category ADD CONSTRAINT FK_356BCD1F10EE4CEE FOREIGN KEY (parentId) REFERENCES ac_unit_budget_category (id)');
+        $this->addSql('ALTER TABLE ac_unit_budget_category RENAME INDEX parentid TO IDX_356BCD1F10EE4CEE');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->addSql('ALTER TABLE ac_cashbook CHANGE id id VARCHAR(36) CHARACTER SET utf8 NOT NULL COLLATE `utf8_czech_ci`');
+        $this->addSql('ALTER TABLE ac_chit_scan CHANGE chit_id chit_id BIGINT UNSIGNED NOT NULL');
+        $this->addSql('ALTER TABLE ac_chit_to_item DROP FOREIGN KEY FK_2EA9AB792AEA3AE4');
+        $this->addSql('ALTER TABLE ac_chit_to_item DROP FOREIGN KEY FK_2EA9AB79126F525E');
+        $this->addSql('ALTER TABLE ac_chit_to_item CHANGE chit_id chit_id BIGINT UNSIGNED NOT NULL');
+        $this->addSql('ALTER TABLE ac_chit_to_item ADD CONSTRAINT FK_2EA9AB792AEA3AE4 FOREIGN KEY (chit_id) REFERENCES ac_chits (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE ac_chit_to_item ADD CONSTRAINT FK_2EA9AB79126F525E FOREIGN KEY (item_id) REFERENCES ac_chits_item (id) ON DELETE CASCADE');
+
+        $this->addSql('ALTER TABLE ac_chits DROP FOREIGN KEY FK_DBBC2DBC2B2EBB6C');
+        $this->addSql(<<<'SQL'
+            ALTER TABLE ac_chits
+                ADD x_purpose VARCHAR(120) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_czech_ci`,
+                ADD x_price DOUBLE PRECISION DEFAULT NULL,
+                ADD x_priceText VARCHAR(100) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_czech_ci`,
+                ADD x_category INT UNSIGNED DEFAULT NULL,
+                ADD x_category_operation_type VARCHAR(255) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_czech_ci` COMMENT '(DC2Type:string_enum)',
+                CHANGE id id BIGINT UNSIGNED AUTO_INCREMENT NOT NULL,
+                CHANGE payment_method payment_method VARCHAR(13) CHARACTER SET utf8 NOT NULL COLLATE `utf8_czech_ci`,
+                CHANGE num num VARCHAR(5) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_czech_ci`,
+                CHANGE date date DATE NOT NULL,
+                CHANGE recipient recipient VARCHAR(64) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_czech_ci`,
+                CHANGE eventId eventId VARCHAR(36) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_czech_ci`
+        SQL);
+
+        $this->addSql('CREATE INDEX category ON ac_chits (x_category)');
+        $this->addSql('ALTER TABLE ac_chits RENAME INDEX idx_dbbc2dbc2b2ebb6c TO eventId');
+        $this->addSql('ALTER TABLE ac_chitsCategory RENAME INDEX UNIQ_43247D658F2890A2 TO short');
+        $this->addSql('ALTER TABLE ac_chitsCategory_object DROP FOREIGN KEY FK_824C4F259C370B71');
+        $this->addSql('ALTER TABLE ac_chitsCategory_object DROP PRIMARY KEY');
+        $this->addSql('ALTER TABLE ac_chitsCategory_object CHANGE objectTypeId objectTypeId VARCHAR(20) CHARACTER SET utf8 NOT NULL COLLATE `utf8_czech_ci`');
+        $this->addSql('ALTER TABLE ac_chitsCategory_object ADD CONSTRAINT ac_chitsCategory_object_ibfk_1 FOREIGN KEY (categoryId) REFERENCES ac_chitsCategory (id) ON UPDATE CASCADE ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE ac_chitsCategory_object RENAME INDEX idx_824c4f259c370b71 TO categoryId');
+        $this->addSql('ALTER TABLE ac_chits_item CHANGE price price DOUBLE PRECISION NOT NULL');
+        $this->addSql(<<<'SQL'
+            ALTER TABLE ac_participants
+                CHANGE id id VARCHAR(36) CHARACTER SET utf8 NOT NULL COLLATE `utf8_czech_ci`,
+                CHANGE participantId participantId INT UNSIGNED NOT NULL COMMENT 'ID',
+                CHANGE payment payment DOUBLE PRECISION UNSIGNED NOT NULL,
+                CHANGE repayment repayment DOUBLE PRECISION UNSIGNED NOT NULL,
+                CHANGE isAccount isAccount VARCHAR(255) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_czech_ci`,
+                CHANGE event_id event_id INT UNSIGNED DEFAULT NULL
+        SQL);
+        $this->addSql('CREATE UNIQUE INDEX participantId_event_type ON ac_participants (participantId, event_type)');
+        $this->addSql('ALTER TABLE ac_unit_budget_category DROP FOREIGN KEY FK_356BCD1F10EE4CEE');
+        $this->addSql('ALTER TABLE ac_unit_budget_category ADD deleted TINYINT(1) DEFAULT \'0\' NOT NULL');
+        $this->addSql('ALTER TABLE ac_unit_budget_category ADD CONSTRAINT ac_unit_budget_category_ibfk_4 FOREIGN KEY (parentId) REFERENCES ac_unit_budget_category (id) ON UPDATE CASCADE');
+        $this->addSql('ALTER TABLE ac_unit_budget_category RENAME INDEX idx_356bcd1f10ee4cee TO parentId');
+    }
+}

--- a/migrations/2020/Version20200214130535.php
+++ b/migrations/2020/Version20200214130535.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20200214130535 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Unify log table and tc_* tables mapping';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $this->addSql('ALTER TABLE tc_vehicle_roadworthy_scan CHANGE file_path file_path VARCHAR(255) NOT NULL COMMENT \'(DC2Type:file_path)\'');
+        $this->addSql(<<<'SQL'
+            ALTER TABLE tc_contracts
+                CHANGE driver_birthday driver_birthday DATE DEFAULT NULL COMMENT '(DC2Type:chronos_date)',
+                CHANGE start start DATE DEFAULT NULL COMMENT '(DC2Type:chronos_date)',
+                CHANGE end end DATE DEFAULT NULL COMMENT '(DC2Type:chronos_date)'
+        SQL);
+        $this->addSql('ALTER TABLE log CHANGE date date DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->addSql('ALTER TABLE log CHANGE date date DATETIME NOT NULL');
+        $this->addSql(<<<'SQL'
+            ALTER TABLE tc_contracts
+                CHANGE start start DATE DEFAULT NULL,
+                CHANGE end end DATE DEFAULT NULL,
+                CHANGE driver_birthday driver_birthday DATE DEFAULT NULL
+        SQL);
+        $this->addSql('ALTER TABLE tc_vehicle_roadworthy_scan CHANGE file_path file_path VARCHAR(255) CHARACTER SET utf8 NOT NULL COLLATE `utf8_unicode_ci`');
+    }
+}

--- a/migrations/2020/Version20200406114332.php
+++ b/migrations/2020/Version20200406114332.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20200406114332 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Map Money objects as integers (amount of cents) in database';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $this->addSql('UPDATE tc_commands SET fuel_price = fuel_price * 100, amortization = amortization * 100');
+        $this->addSql(<<<'SQL'
+            ALTER TABLE tc_commands
+                CHANGE fuel_price fuel_price INT NOT NULL COMMENT '(DC2Type:money)',
+                CHANGE amortization amortization INT NOT NULL COMMENT '(DC2Type:money)'
+        SQL);
+
+        $this->addSql('UPDATE ac_participants SET payment = payment * 100, repayment = repayment * 100');
+        $this->addSql(<<<'SQL'
+            ALTER TABLE ac_participants
+                CHANGE payment payment INT NOT NULL COMMENT '(DC2Type:money)',
+                CHANGE repayment repayment INT NOT NULL COMMENT '(DC2Type:money)'
+        SQL);
+
+        $this->addSql('UPDATE tc_travels SET price = price * 100');
+        $this->addSql(<<<'SQL'
+            ALTER TABLE tc_travels CHANGE price price INT DEFAULT NULL COMMENT '(DC2Type:money)'
+        SQL);
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE ac_participants
+                CHANGE payment payment NUMERIC(8, 2) NOT NULL COMMENT '(DC2Type:money)',
+                CHANGE repayment repayment NUMERIC(8, 2) NOT NULL COMMENT '(DC2Type:money)'
+        SQL);
+        $this->addSql('UPDATE ac_participants SET payment = payment / 100, repayment = repayment / 100');
+
+        $this->addSql(<<<'SQL'
+            ALTER TABLE tc_commands
+                CHANGE fuel_price fuel_price NUMERIC(8, 2) NOT NULL COMMENT '(DC2Type:money)',
+                CHANGE amortization amortization NUMERIC(8, 2) NOT NULL COMMENT '(DC2Type:money)'
+        SQL);
+        $this->addSql('UPDATE tc_commands SET fuel_price = fuel_price / 100, amortization = amortization / 100');
+
+        $this->addSql(<<<'SQL'
+            ALTER TABLE tc_travels CHANGE price price NUMERIC(8, 2) DEFAULT NULL COMMENT '(DC2Type:money)'
+        SQL);
+        $this->addSql('UPDATE tc_travels SET price = price / 100');
+    }
+}

--- a/tests/integration/Cashbook/CashbookIntegrationTest.php
+++ b/tests/integration/Cashbook/CashbookIntegrationTest.php
@@ -135,6 +135,10 @@ class CashbookIntegrationTest extends IntegrationTest
         /** @var ChitWasRemoved $event */
         $this->assertTrue($event->getCashbookId()->equals($cashbookId));
         $this->assertSame('purpose', $event->getChitPurpose());
+
+        // Test that everything cascades correctly
+        $this->entityManager->persist($cashbook);
+        $this->entityManager->flush();
     }
 
     public function testRemovalOfLockedChitThrowsException() : void

--- a/tests/integration/Infrastructure/Repositories/Travel/CommandRepositoryTest.php
+++ b/tests/integration/Infrastructure/Repositories/Travel/CommandRepositoryTest.php
@@ -11,7 +11,7 @@ use IntegrationTest;
 use Model\Travel\Command;
 use Model\Travel\Travel\TransportType;
 use Model\Travel\Vehicle;
-use Model\Utils\MoneyFactory;
+use Money\Money;
 use Nette\Utils\Json;
 use function array_diff_key;
 use function array_map;
@@ -26,8 +26,8 @@ class CommandRepositoryTest extends IntegrationTest
         'place' => 'Krno',
         'passengers' => 'František Maša sr.',
         'vehicle_id' => null,
-        'fuel_price' => 15,
-        'amortization' => 3,
+        'fuel_price' => 1500,
+        'amortization' => 300,
         'note' => 'Poznámka',
         'driver_name' => 'František Maša',
         'driver_contact' => '123456789',
@@ -137,8 +137,8 @@ class CommandRepositoryTest extends IntegrationTest
         $this->assertSame(self::COMMAND['unit_id'], $command->getUnitId());
         $this->assertSame(self::COMMAND['purpose'], $command->getPurpose());
         $this->assertSame(self::COMMAND['passengers'], $command->getFellowPassengers());
-        $this->assertEquals(MoneyFactory::fromFloat(self::COMMAND['fuel_price']), $command->getFuelPrice());
-        $this->assertEquals(MoneyFactory::fromFloat(self::COMMAND['amortization']), $command->getAmortization());
+        $this->assertEquals(Money::CZK(self::COMMAND['fuel_price']), $command->getFuelPrice());
+        $this->assertEquals(Money::CZK(self::COMMAND['amortization']), $command->getAmortization());
         $this->assertEquals(new DateTimeImmutable(self::COMMAND['closed']), $command->getClosedAt());
         $this->assertSame(self::COMMAND['note'], $command->getNote());
 
@@ -167,7 +167,7 @@ class CommandRepositoryTest extends IntegrationTest
         $this->assertSame(1, $transportTravel->getId());
         $details2 = $transportTravel->getDetails();
         $this->assertInstanceOf(Command\TransportTravel::class, $transportTravel);
-        $this->assertEquals(MoneyFactory::fromFloat(self::TRANSPORT_TRAVEL['price']), $transportTravel->getPrice());
+        $this->assertEquals(Money::CZK(self::TRANSPORT_TRAVEL['price']), $transportTravel->getPrice());
         $this->assertTrue($details2->getDate()->eq(new Date(self::TRANSPORT_TRAVEL['start_date'])));
         $this->assertSame(self::TRANSPORT_TRAVEL['start_place'], $details2->getStartPlace());
         $this->assertSame(self::TRANSPORT_TRAVEL['end_place'], $details2->getEndPlace());


### PR DESCRIPTION
Část https://github.com/skaut/Skautske-hospodareni/issues/880, po mergnutí navážu ještě jedním PR se sjednocením názvů sloupců a indexů.

Změny, které stojí za zmínit:
- **Enumy jsou mapované jako varchar místo MySQL enumů** - alternativou je buď psát u sloupců vždy vlastní columnDefinition (kde musíme znát všechny hodnoty enumů), nebo definování vlastního typu pro daný enum
- **Money objekty jsou mapovány jako INT v centech** (tedy *25,50 Kč* se místo `25.5` mapuje jako `2550` - k tomu jsem přistoupil proto, že by alternativou byla potřeba ručního nastavování `precision` a `scale` u všech properties, které by měly `type="money"`
- **`TravelType::$price` a `VehicleType::$distance` jsou mapované jako samostatné sloupce** - tím, že je teď Money mapovaný jako INT, tak by `MoneyType` musel umět pracovat i s `float`, i když ho nikde sám nepodporuje - navíc to IMO dává v DB větší smysl než mít cenu ve sloupci `distance`
- **Odebrány `x_*` sloupce v `ac_chits`** - ty jsou tam jako pozůstatek pro jednodušší rollback více položek u dokladu, ale teď už nám tam nedávají smysl a v aplikaci ani nebyly mapovány 

----

@sinacek Prosím o podrobnější review. Testoval jsem průchody v obou směrech několikrát, ale je toho tolik, že bych byl rád, abys na to důkladně mrknul :wink:

