### PR TITLE
PHP 7.4

### DIFF
--- a/.docs/instalace.md
+++ b/.docs/instalace.md
@@ -1,7 +1,7 @@
 # Instalace pro lokální vývoj
 
 Aplikace vyžaduje:
-- PHP 7.3
+- PHP 7.4
 - MySQL 5
 - Apache
 - Composer

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
         name: "Prepare working directory"
         runs-on: ubuntu-18.04
         container:
-            image: fmasa/lebeda:7.3
+            image: fmasa/lebeda:7.4
         steps:
             - uses: actions/checkout@v2
             # Copy & paste from https://github.com/actions/cache/blob/master/examples.md#php---composer
@@ -34,7 +34,7 @@ jobs:
         name: "Run unit tests"
         runs-on: ubuntu-18.04
         container:
-            image: fmasa/lebeda:7.3
+            image: fmasa/lebeda:7.4
         needs: workdir
         steps:
             - name: Download workdir
@@ -50,7 +50,7 @@ jobs:
         name: "Run integration tests"
         runs-on: ubuntu-18.04
         container:
-            image: fmasa/lebeda:7.3
+            image: fmasa/lebeda:7.4
         needs: workdir
 
         services:
@@ -78,7 +78,7 @@ jobs:
         name: "Run PHPStan analysis"
         runs-on: ubuntu-18.04
         container:
-            image: fmasa/lebeda:7.3
+            image: fmasa/lebeda:7.4
         needs: workdir
         steps:
             - name: Download workdir
@@ -94,7 +94,7 @@ jobs:
         name: "Check coding standard"
         runs-on: ubuntu-18.04
         container:
-            image: fmasa/lebeda:7.3
+            image: fmasa/lebeda:7.4
         needs: workdir
         steps:
             - name: Download workdir
@@ -110,7 +110,7 @@ jobs:
         name: "Lint Latte templates"
         runs-on: ubuntu-18.04
         container:
-            image: fmasa/lebeda:7.3
+            image: fmasa/lebeda:7.4
         needs: workdir
         env:
             DEVELOPMENT_MACHINE: true

--- a/app/model/Payment/ReadModel/QueryHandlers/CountGroupsWithBankAccountQueryHandler.php
+++ b/app/model/Payment/ReadModel/QueryHandlers/CountGroupsWithBankAccountQueryHandler.php
@@ -21,7 +21,7 @@ final class CountGroupsWithBankAccountQueryHandler
     {
         return (int) $this->entityManager
             ->createQuery(/** @lang DQL */ 'SELECT COUNT(g) FROM Model\Payment\Group g WHERE g.bankAccount.id = :id')
-            ->setParameters(['id' => $query->getBankAccountId()->toInt()])
+            ->setParameter('id', $query->getBankAccountId()->toInt())
             ->getSingleScalarResult();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
         "contributte/codeception": "^1.1"
     },
     "autoload-dev": {
-        "classmap": ["code-quality/"]
+        "classmap": ["code-quality/", "tests/_hacks"]
     },
     "prefer-stable": true,
     "minimum-stability": "dev"

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "skautskeHospodareni",
     "type": "project",
     "require": {
-        "php": ">= 7.3",
+        "php": ">= 7.4",
         "nette/application": "~2.4",
         "nette/bootstrap": "~2.4",
         "nette/caching": " ~2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3368d5d3264fdbbff7acf7bfb8b4b94b",
+    "content-hash": "9823514ea09f61c41c2bcbcd893d431d",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1129,16 +1129,16 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "v2.6.3",
+            "version": "v2.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "434820973cadf2da2d66e7184be370084cc32ca8"
+                "reference": "2d9b9351831d1230881c52f006011cbf72fe944e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/434820973cadf2da2d66e7184be370084cc32ca8",
-                "reference": "434820973cadf2da2d66e7184be370084cc32ca8",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/2d9b9351831d1230881c52f006011cbf72fe944e",
+                "reference": "2d9b9351831d1230881c52f006011cbf72fe944e",
                 "shasum": ""
             },
             "require": {
@@ -1153,9 +1153,8 @@
                 "symfony/console": "~3.0|~4.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^1.0",
-                "phpunit/phpunit": "^6.5",
-                "squizlabs/php_codesniffer": "^3.2",
+                "doctrine/coding-standard": "^5.0",
+                "phpunit/phpunit": "^7.5",
                 "symfony/yaml": "~3.4|~4.0"
             },
             "suggest": {
@@ -1181,16 +1180,16 @@
             ],
             "authors": [
                 {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
                     "name": "Roman Borschel",
                     "email": "roman@code-factory.org"
                 },
                 {
                     "name": "Benjamin Eberlei",
                     "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
                 },
                 {
                     "name": "Jonathan Wage",
@@ -1207,7 +1206,7 @@
                 "database",
                 "orm"
             ],
-            "time": "2018-11-20T23:46:46+00:00"
+            "time": "2019-11-18T22:01:21+00:00"
         },
         {
             "name": "doctrine/persistence",
@@ -2448,6 +2447,177 @@
                 "strict"
             ],
             "time": "2016-08-26T06:34:41+00:00"
+        },
+        {
+            "name": "laminas/laminas-code",
+            "version": "3.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-code.git",
+                "reference": "1cb8f203389ab1482bf89c0e70a04849bacd7766"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-code/zipball/1cb8f203389ab1482bf89c0e70a04849bacd7766",
+                "reference": "1cb8f203389ab1482bf89c0e70a04849bacd7766",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-eventmanager": "^2.6 || ^3.0",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^7.1"
+            },
+            "conflict": {
+                "phpspec/prophecy": "<1.9.0"
+            },
+            "replace": {
+                "zendframework/zend-code": "self.version"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.7",
+                "ext-phar": "*",
+                "laminas/laminas-coding-standard": "^1.0",
+                "laminas/laminas-stdlib": "^2.7 || ^3.0",
+                "phpunit/phpunit": "^7.5.16 || ^8.4"
+            },
+            "suggest": {
+                "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",
+                "laminas/laminas-stdlib": "Laminas\\Stdlib component"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4.x-dev",
+                    "dev-develop": "3.5.x-dev",
+                    "dev-dev-4.0": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Code\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Extensions to the PHP Reflection API, static code scanning, and code generation",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "code",
+                "laminas"
+            ],
+            "time": "2019-12-31T16:28:24+00:00"
+        },
+        {
+            "name": "laminas/laminas-eventmanager",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-eventmanager.git",
+                "reference": "ce4dc0bdf3b14b7f9815775af9dfee80a63b4748"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/ce4dc0bdf3b14b7f9815775af9dfee80a63b4748",
+                "reference": "ce4dc0bdf3b14b7f9815775af9dfee80a63b4748",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-eventmanager": "self.version"
+            },
+            "require-dev": {
+                "athletic/athletic": "^0.1",
+                "container-interop/container-interop": "^1.1.0",
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-stdlib": "^2.7.3 || ^3.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
+            },
+            "suggest": {
+                "container-interop/container-interop": "^1.1.0, to use the lazy listeners feature",
+                "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev",
+                    "dev-develop": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\EventManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Trigger and listen to events within a PHP application",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "event",
+                "eventmanager",
+                "events",
+                "laminas"
+            ],
+            "time": "2019-12-31T16:44:52+00:00"
+        },
+        {
+            "name": "laminas/laminas-zendframework-bridge",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
+                "reference": "0fb9675b84a1666ab45182b6c5b29956921e818d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/0fb9675b84a1666ab45182b6c5b29956921e818d",
+                "reference": "0fb9675b84a1666ab45182b6c5b29956921e818d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev",
+                    "dev-develop": "1.1.x-dev"
+                },
+                "laminas": {
+                    "module": "Laminas\\ZendFrameworkBridge"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Laminas\\ZendFrameworkBridge\\": "src//"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
+            "keywords": [
+                "ZendFramework",
+                "autoloading",
+                "laminas",
+                "zf"
+            ],
+            "time": "2020-01-07T22:58:31+00:00"
         },
         {
             "name": "latte/latte",
@@ -6834,119 +7004,6 @@
             ],
             "description": "Doctrine DBAL Types to use Chronos' Immutable DateTime Objects",
             "time": "2019-03-31T17:05:33+00:00"
-        },
-        {
-            "name": "zendframework/zend-code",
-            "version": "3.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-code.git",
-                "reference": "268040548f92c2bfcba164421c1add2ba43abaaa"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/268040548f92c2bfcba164421c1add2ba43abaaa",
-                "reference": "268040548f92c2bfcba164421c1add2ba43abaaa",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1",
-                "zendframework/zend-eventmanager": "^2.6 || ^3.0"
-            },
-            "conflict": {
-                "phpspec/prophecy": "<1.9.0"
-            },
-            "require-dev": {
-                "doctrine/annotations": "^1.7",
-                "ext-phar": "*",
-                "phpunit/phpunit": "^7.5.16 || ^8.4",
-                "zendframework/zend-coding-standard": "^1.0",
-                "zendframework/zend-stdlib": "^2.7 || ^3.0"
-            },
-            "suggest": {
-                "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",
-                "zendframework/zend-stdlib": "Zend\\Stdlib component"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4.x-dev",
-                    "dev-develop": "3.5.x-dev",
-                    "dev-dev-4.0": "4.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zend\\Code\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Extensions to the PHP Reflection API, static code scanning, and code generation",
-            "keywords": [
-                "ZendFramework",
-                "code",
-                "zf"
-            ],
-            "abandoned": "laminas/laminas-code",
-            "time": "2019-12-10T19:21:15+00:00"
-        },
-        {
-            "name": "zendframework/zend-eventmanager",
-            "version": "3.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-eventmanager.git",
-                "reference": "a5e2583a211f73604691586b8406ff7296a946dd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-eventmanager/zipball/a5e2583a211f73604691586b8406ff7296a946dd",
-                "reference": "a5e2583a211f73604691586b8406ff7296a946dd",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0"
-            },
-            "require-dev": {
-                "athletic/athletic": "^0.1",
-                "container-interop/container-interop": "^1.1.0",
-                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
-                "zendframework/zend-coding-standard": "~1.0.0",
-                "zendframework/zend-stdlib": "^2.7.3 || ^3.0"
-            },
-            "suggest": {
-                "container-interop/container-interop": "^1.1.0, to use the lazy listeners feature",
-                "zendframework/zend-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.2-dev",
-                    "dev-develop": "3.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zend\\EventManager\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Trigger and listen to events within a PHP application",
-            "homepage": "https://github.com/zendframework/zend-eventmanager",
-            "keywords": [
-                "event",
-                "eventmanager",
-                "events",
-                "zf2"
-            ],
-            "abandoned": "laminas/laminas-eventmanager",
-            "time": "2018-04-25T15:33:34+00:00"
         }
     ],
     "packages-dev": [
@@ -10740,7 +10797,8 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">= 7.3"
+        "php": ">= 7.4"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.4'
 services:
     app:
         container_name: hskauting.app
-        image: fmasa/lebeda:7.3
+        image: fmasa/lebeda:7.4
         volumes:
             - www:/var/www
             - .:/var/www/html

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,6 +7,7 @@ parameters:
     ignoreErrors:
         # Errors related mostly to usage of assert($x instanceof A || $x === null) and similar asserts
         - '~Result of && is always true\.~'
+        - '~Parameter #1 \$parameters of method Doctrine\\ORM\\AbstractQuery::setParameters\(\).*~'
 
 includes:
     - vendor/phpstan/phpstan-nette/extension.neon

--- a/tests/_hacks/SoapCodeTransform.php
+++ b/tests/_hacks/SoapCodeTransform.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace VCR\CodeTransform;
+
+class SoapCodeTransform extends AbstractCodeTransform
+{
+    public const NAME = 'vcr_soap';
+
+    protected function transformCode($code)
+    {
+        return $code;
+    }
+}

--- a/tests/_support/SkautisTest.php
+++ b/tests/_support/SkautisTest.php
@@ -17,7 +17,7 @@ abstract  class SkautisTest extends Unit
     protected function createSkautis(string $loginId) : Skautis
     {
         $config      = new Config('48104fe2-b447-47f5-9a26-051c710da74e', true, true, true);
-        $wsdlManager = new WsdlManager(new WebServiceFactory(), $config);
+        $wsdlManager = new WsdlManager(new WebServiceFactory(WebServiceWithInterception::class), $config);
         $user        = new User($wsdlManager, new FakeAdapter());
 
         $user->setLoginData($loginId);

--- a/tests/_support/WebServiceWithInterception.php
+++ b/tests/_support/WebServiceWithInterception.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hskauting\Tests;
+
+use Skautis\InvalidArgumentException;
+use Skautis\Wsdl\WebService;
+use VCR\Util\SoapClient;
+
+class WebServiceWithInterception extends WebService
+{
+    public function __construct($wsdl, array $soapOpts)
+    {
+        $this->init = $soapOpts;
+
+        if (empty($wsdl)) {
+            throw new InvalidArgumentException("WSDL address cannot be empty.");
+        }
+
+        $this->soapClient = new SoapClient($wsdl, $soapOpts);
+    }
+}

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: fmasa/lebeda:7.3-ci
+box: fmasa/lebeda:7.4-ci
 
 build:
 


### PR DESCRIPTION
Popíšu těch pár změn:
- 2dc73e4 řeší nekompatibilitu PHP-VCR s PHP 7.4 (existuje PR https://github.com/php-vcr/php-vcr/pull/293), ale ten projekt je 2 roky prakticky mrtvý. Pokud by se těch nekompatibilit v budoucnu objevilo více, tak je ideální cesta fork.
- 000dee1 Doctrine měla nekompatibilitu s PHP 7.4, kterou fixli v novější verzi. Tak jsem ji aktualizoval, ale je tam kolize s PHPstanem, který špatně interpretuje jeden phpdoc (`ArrayCollection|Foo[]` bere jako `ArrayCollection<Foo>`) - takže jsem jeden error přidal do ignorovaných. 