### PR TITLE
Abstrakce pro modální dialogy

### DIFF
--- a/app/AccountancyModule/CampModule/Components/ExportDialog.php
+++ b/app/AccountancyModule/CampModule/Components/ExportDialog.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\AccountancyModule\CampModule\Components;
 
-use App\AccountancyModule\Components\BaseControl;
+use App\AccountancyModule\Components\Dialog;
 use App\AccountancyModule\ExcelResponse;
 use App\Forms\BaseForm;
 use Cake\Chronos\Date;
@@ -16,16 +16,12 @@ use Nette\Utils\ArrayHash;
 use function sprintf;
 use function uasort;
 
-final class ExportDialog extends BaseControl
+final class ExportDialog extends Dialog
 {
-    /** @var bool @persistent */
-    public $opened = false;
-
     /** @var CampListItem[] */
-    private $camps;
+    private array $camps;
 
-    /** @var QueryBus */
-    private $queryBus;
+    private QueryBus $queryBus;
 
     /**
      * @param CampListItem[] $camps
@@ -39,16 +35,12 @@ final class ExportDialog extends BaseControl
 
     public function handleOpen() : void
     {
-        $this->opened = true;
-        $this->redrawControl();
+        $this->show();
     }
 
-    public function render() : void
+    protected function beforeRender() : void
     {
         $this->template->setFile(__DIR__ . '/templates/ExportDialog.latte');
-        $this->template->setParameters(['renderModal' => $this->opened]);
-
-        $this->template->render();
     }
 
     protected function createComponentForm() : BaseForm

--- a/app/AccountancyModule/CampModule/Components/templates/ExportDialog.latte
+++ b/app/AccountancyModule/CampModule/Components/templates/ExportDialog.latte
@@ -1,33 +1,22 @@
-<div n:snippet n:inner-if="$renderModal" class="modal" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">Exportovat souhrn táborů</h5>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <div class="modal-body">
-                Vyberte tábory, které chcete exportovat.
+{layout $layout}
 
-                <div class="mt-2 ml-2">
-                    <div class="form-check mb-1">
-                        <input type="checkbox" class="form-check-input" id="export-check-all"
-                               data-dependent-checkboxes=".export-dependent-checkboxes">
-                        <label for="export-check-all" class="font-weight-bold">Vybrat vše</label>
-                    </div>
-                    <form n:name="form" class="export-dependent-checkboxes">
-                        <div class="form-check" n:foreach="$form['campIds']->items as $key => $label">
-                            <input n:name="campIds:$key" class="form-check-input">
-                            <label n:name="campIds:$key" class="form-check-label">{$label}</label>
-                        </div>
-                        <input n:name="download" class="btn btn-primary">
-                    </form>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-light" data-dismiss="modal">Storno</button>
-            </div>
+{block dialog-title}Exportovat souhrn táborů{/block}
+
+{block dialog-body}
+    Vyberte tábory, které chcete exportovat.
+
+    <div class="mt-2 ml-2">
+        <div class="form-check mb-1">
+            <input type="checkbox" class="form-check-input" id="export-check-all"
+                   data-dependent-checkboxes=".export-dependent-checkboxes">
+            <label for="export-check-all" class="font-weight-bold">Vybrat vše</label>
         </div>
+        <form n:name="form" class="export-dependent-checkboxes">
+            <div class="form-check" n:foreach="$form['campIds']->items as $key => $label">
+                <input n:name="campIds:$key" class="form-check-input">
+                <label n:name="campIds:$key" class="form-check-label">{$label}</label>
+            </div>
+            <input n:name="download" class="btn btn-primary">
+        </form>
     </div>
-</div>
+{/block}

--- a/app/AccountancyModule/Components/Dialog.php
+++ b/app/AccountancyModule/Components/Dialog.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AccountancyModule\Components;
+
+use Nette\InvalidStateException;
+
+/**
+ * Abstract parent that implements basic functionality related to making modal dialogs.
+ *
+ * To create custom dialog simply extend this class and set template file (that extends from $layout) in beforeRender()
+ * Parts of dialog can be changed by overwriting blocks `dialog-title`, `dialog-body`, `dialog-footer`.
+ */
+abstract class Dialog extends BaseControl
+{
+    /**
+     * @internal
+     *
+     * @var bool @persistent
+     */
+    public $opened = false;
+
+    protected function beforeRender() : void
+    {
+    }
+
+    final public function render() : void
+    {
+        $this->beforeRender();
+
+        $this->template->setParameters([
+            'layout' => __DIR__ . '/templates/Dialog.layout.latte',
+            'renderModal' => $this->opened,
+        ]);
+
+        if ($this->template->getFile() === null) {
+            throw new InvalidStateException('No template file has been set for dialog');
+        }
+
+        $this->template->render();
+    }
+
+    protected function show() : void
+    {
+        $this->opened = true;
+        $this->redrawControl();
+    }
+
+    protected function hide() : void
+    {
+        $this->opened = false;
+        $this->redrawControl();
+    }
+}

--- a/app/AccountancyModule/Components/templates/Dialog.layout.latte
+++ b/app/AccountancyModule/Components/templates/Dialog.layout.latte
@@ -1,0 +1,16 @@
+<div n:snippet n:inner-if="$renderModal" class="modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" n:inner-block="dialog-title"></h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body" n:inner-block="dialog-body"></div>
+            <div class="modal-footer" n:inner-block="dialog-footer">
+                <button type="button" class="btn btn-light" data-dismiss="modal">Storno</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/AccountancyModule/EventModule/components/ExportDialog.php
+++ b/app/AccountancyModule/EventModule/components/ExportDialog.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\AccountancyModule\EventModule\Components;
 
-use App\AccountancyModule\Components\BaseControl;
+use App\AccountancyModule\Components\Dialog;
 use App\AccountancyModule\ExcelResponse;
 use App\Forms\BaseForm;
 use Cake\Chronos\Date;
@@ -16,16 +16,12 @@ use Nette\Utils\ArrayHash;
 use function sprintf;
 use function uasort;
 
-final class ExportDialog extends BaseControl
+final class ExportDialog extends Dialog
 {
-    /** @var bool @persistent */
-    public $opened = false;
-
     /** @var EventListItem[] */
-    private $events;
+    private array $events;
 
-    /** @var QueryBus */
-    private $queryBus;
+    private QueryBus $queryBus;
 
     /**
      * @param EventListItem[] $events
@@ -39,16 +35,12 @@ final class ExportDialog extends BaseControl
 
     public function handleOpen() : void
     {
-        $this->opened = true;
-        $this->redrawControl();
+        $this->show();
     }
 
-    public function render() : void
+    protected function beforeRender() : void
     {
         $this->template->setFile(__DIR__ . '/templates/ExportDialog.latte');
-        $this->template->setParameters(['renderModal' => $this->opened]);
-
-        $this->template->render();
     }
 
     protected function createComponentForm() : BaseForm

--- a/app/AccountancyModule/EventModule/components/templates/ExportDialog.latte
+++ b/app/AccountancyModule/EventModule/components/templates/ExportDialog.latte
@@ -1,32 +1,21 @@
-<div n:snippet n:inner-if="$renderModal" class="modal" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">Exportovat souhrn akcí</h5>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <div class="modal-body">
-                Vyberte akce, které chcete exportovat.
+{layout $layout}
 
-                <div class="mt-2 ml-2">
-                    <div class="form-check mb-1">
-                        <input type="checkbox" class="form-check-input" id="export-check-all" data-dependent-checkboxes=".export-dependent-checkboxes">
-                        <label for="export-check-all" class="font-weight-bold">Vybrat vše</label>
-                    </div>
-                    <form n:name="form" class="export-dependent-checkboxes">
-                        <div class="form-check" n:foreach="$form['eventIds']->items as $key => $label">
-                            <input n:name="eventIds:$key" class="form-check-input">
-                            <label n:name="eventIds:$key" class="form-check-label">{$label}</label>
-                        </div>
-                        <input n:name="download" class="btn btn-primary">
-                    </form>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-light" data-dismiss="modal">Storno</button>
-            </div>
+{block dialog-title}Exportovat souhrn akcí{/block}
+
+{block dialog-body}
+    Vyberte akce, které chcete exportovat.
+
+    <div class="mt-2 ml-2">
+        <div class="form-check mb-1">
+            <input type="checkbox" class="form-check-input" id="export-check-all" data-dependent-checkboxes=".export-dependent-checkboxes">
+            <label for="export-check-all" class="font-weight-bold">Vybrat vše</label>
         </div>
+        <form n:name="form" class="export-dependent-checkboxes">
+            <div class="form-check" n:foreach="$form['eventIds']->items as $key => $label">
+                <input n:name="eventIds:$key" class="form-check-input">
+                <label n:name="eventIds:$key" class="form-check-label">{$label}</label>
+            </div>
+            <input n:name="download" class="btn btn-primary">
+        </form>
     </div>
-</div>
+{/block}

--- a/app/AccountancyModule/PaymentModule/components/PaymentDialog.php
+++ b/app/AccountancyModule/PaymentModule/components/PaymentDialog.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\AccountancyModule\PaymentModule\Components;
 
-use App\AccountancyModule\Components\BaseControl;
+use App\AccountancyModule\Components\Dialog;
 use App\Forms\BaseForm;
 use Assert\Assertion;
 use eGen\MessageBus\Bus\CommandBus;
@@ -18,7 +18,7 @@ use Nette\Utils\ArrayHash;
 /**
  * @method void onSuccess()
  */
-final class PaymentDialog extends BaseControl
+final class PaymentDialog extends Dialog
 {
     /** @var callable[] */
     public $onSuccess = [];
@@ -28,12 +28,6 @@ final class PaymentDialog extends BaseControl
      * @var int
      */
     public $paymentId = -1;
-
-    /**
-     * @persistent
-     * @var bool
-     */
-    public $open = false;
 
     /** @var int */
     private $groupId;
@@ -55,21 +49,17 @@ final class PaymentDialog extends BaseControl
     public function handleOpen(int $paymentId = -1) : void
     {
         $this->paymentId = $paymentId;
-        $this->open      = true;
 
-        $this->redrawControl();
+        $this->show();
     }
 
-    public function render() : void
+    protected function beforeRender() : void
     {
+        $this->template->setFile(__DIR__ . '/templates/PaymentDialog.latte');
         $this->template->setParameters([
             'payment' => $this->payment(),
             'editing' => $this->isEditing(),
-            'renderModal' => $this->open,
         ]);
-
-        $this->template->setFile(__DIR__ . '/templates/PaymentDialog.latte');
-        $this->template->render();
     }
 
     protected function createComponentForm() : BaseForm
@@ -157,7 +147,7 @@ final class PaymentDialog extends BaseControl
         }
 
         $this->onSuccess();
-        $this->close();
+        $this->hide();
     }
 
     private function updatePayment(ArrayHash $values) : void
@@ -166,7 +156,7 @@ final class PaymentDialog extends BaseControl
 
         if ($payment === null) {
             $this->presenter->flashMessage('Zadaná platba neexistuje', 'danger');
-            $this->close();
+            $this->hide();
 
             return;
         }
@@ -203,7 +193,7 @@ final class PaymentDialog extends BaseControl
         );
 
         $this->flashMessage('Platba byla přidána', 'success');
-        $this->close();
+        $this->hide();
     }
 
     private function isEditing() : bool
@@ -224,13 +214,5 @@ final class PaymentDialog extends BaseControl
         }
 
         return $payment;
-    }
-
-    private function close() : void
-    {
-        $this->paymentId = -1;
-        $this->open      = false;
-
-        $this->redrawControl();
     }
 }

--- a/app/AccountancyModule/PaymentModule/components/RemoveGroupDialog.php
+++ b/app/AccountancyModule/PaymentModule/components/RemoveGroupDialog.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\AccountancyModule\PaymentModule\Components;
 
-use App\AccountancyModule\Components\BaseControl;
+use App\AccountancyModule\Components\Dialog;
 use App\Forms\BaseForm;
 use eGen\MessageBus\Bus\CommandBus;
 use Model\Payment\Commands\Group\RemoveGroup;
@@ -12,11 +12,8 @@ use Model\PaymentService;
 use Nette\Application\BadRequestException;
 use Nette\Http\IResponse;
 
-final class RemoveGroupDialog extends BaseControl
+final class RemoveGroupDialog extends Dialog
 {
-    /** @var bool */
-    private $opened = false;
-
     /** @var int */
     private $groupId;
 
@@ -49,7 +46,7 @@ final class RemoveGroupDialog extends BaseControl
         $this->redrawControl();
     }
 
-    public function render() : void
+    protected function beforeRender() : void
     {
         $group = $this->paymentService->getGroup($this->groupId);
 
@@ -57,13 +54,8 @@ final class RemoveGroupDialog extends BaseControl
             throw new BadRequestException('Skupina plateb neexistuje');
         }
 
-        $this->template->setParameters([
-            'groupName' => $group->getName(),
-            'renderModal' => $this->opened,
-        ]);
-
         $this->template->setFile(__DIR__ . '/templates/RemoveGroupDialog.latte');
-        $this->template->render();
+        $this->template->setParameters(['groupName' => $group->getName()]);
     }
 
     protected function createComponentForm() : BaseForm

--- a/app/AccountancyModule/PaymentModule/components/SmtpUpdateForm.php
+++ b/app/AccountancyModule/PaymentModule/components/SmtpUpdateForm.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace App\AccountancyModule\PaymentModule\Components;
 
-use App\AccountancyModule\Components\BaseControl;
+use App\AccountancyModule\Components\Dialog;
 use App\Forms\BaseForm;
 use eGen\MessageBus\Bus\CommandBus;
 use Model\Common\UnitId;
 use Model\Payment\Commands\UpdateMailPassword;
 use Nette\Application\UI\Form;
 
-final class SmtpUpdateForm extends BaseControl
+final class SmtpUpdateForm extends Dialog
 {
     /** @var UnitId */
     private $unitId;
@@ -37,16 +37,13 @@ final class SmtpUpdateForm extends BaseControl
     public function handleOpen(int $smtpId) : void
     {
         $this->smtpId = $smtpId;
-        $this->redrawControl();
+
+        $this->show();
     }
 
-    public function render() : void
+    protected function beforeRender() : void
     {
-        $this->template->setParameters([
-            'renderModal' => $this->smtpId !== null,
-        ]);
         $this->template->setFile(__DIR__ . '/templates/SmtpUpdateForm.latte');
-        $this->template->render();
     }
 
     protected function createComponentForm() : BaseForm
@@ -57,7 +54,7 @@ final class SmtpUpdateForm extends BaseControl
             ->addRule(Form::FILLED, 'Musíte vyplnit heslo.');
         $form->addHidden('smtpId', $this->smtpId);
         $form->addSubmit('send', 'Nastavit heslo')
-            ->setAttribute('class', 'btn btn-primary');
+            ->setAttribute('class', 'btn btn-primary btn-lg w-100 mt-2 ajax');
 
         $form->onSuccess[] = function (BaseForm $form) : void {
             $this->formSucceeded($form);

--- a/app/AccountancyModule/PaymentModule/components/templates/PaymentDialog.latte
+++ b/app/AccountancyModule/PaymentModule/components/templates/PaymentDialog.latte
@@ -1,3 +1,5 @@
+{layout $layout}
+
 {define control $input, $extraClasses}
     <input n:name="$input" n:class="$input->hasErrors() ? 'is-invalid', form-control, $extraClasses ?? ''">
 {/define}
@@ -6,98 +8,90 @@
     <div class="invalid-feedback d-block" n:foreach="$input->getErrors() as $error">{$error}</div>
 {/define}
 
-<div n:snippet n:inner-if="$renderModal" class="modal" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">{if $editing}Upravit platbu{else}Přidat platbu{/if}</h5>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
+{block dialog-title}{if $editing}Upravit platbu{else}Přidat platbu{/if}{/block}
+
+{block dialog-body}
+    {if $editing && $payment === null}
+        <div class="alert alert-danger">Zadaná platba neexistuje.</div>
+    {else}
+        <form n:name="form" class="inline-errors">
+            <div class="form-group">
+                <label n:name="name"/>
+                {include control $form['name']}
+                {include errors $form['name']}
             </div>
-            <div class="modal-body pl-4 pr-4">
-                {if $editing && $payment === null}
-                    <div class="alert alert-danger">Zadaná platba neexistuje.</div>
-                {else}
-                    <form n:name="form" class="inline-errors">
-                        <div class="form-group">
-                            <label n:name="name"/>
-                            {include control $form['name']}
-                            {include errors $form['name']}
-                        </div>
 
-                        <div class="form-group">
-                            <label n:name="email"/>
-                            <small class="text-muted">volitelný</small>
-                            {include control $form['email']}
-                            {include errors $form['email']}
-                        </div>
-
-                        <div class="form-group">
-                            <label n:name="amount"/>
-                            <div class="input-group w-50">
-                                {include control $form['amount']}
-                                <div class="input-group-append">
-                                    <div class="input-group-text">
-                                        Kč
-                                    </div>
-                                </div>
-                            </div>
-                            {include errors $form['amount']}
-                        </div>
-
-                        <div class="form-group">
-                            <label n:name="dueDate"/>
-                            <div class="input-group w-50">
-                                <div class="input-group-prepend">
-                                    <div class="input-group-text">
-                                        <i class="far fa-calendar"></i>
-                                    </div>
-                                </div>
-                                {include control $form['dueDate'], 'date'}
-                            </div>
-                            {include errors $form['dueDate']}
-                        </div>
-
-                        <div class="row">
-                            <div class="col-md-6 pr-0">
-                                <div class="form-group">
-                                    <label n:name="variableSymbol"/>
-                                    <small class="text-muted">volitelný</small>
-                                    <div class="input-group">
-                                        {include control $form['variableSymbol']}
-                                         <div class="input-group-append"
-                                              title="Předvyplněná hodnota je dosavadní nejvyšší hodnota +1"
-                                               data-toggle="tooltip">
-                                             <div class="input-group-text">
-                                                <i class="fas fa-info-circle hidden-xs hidden-sm"></i>
-                                             </div>
-                                        </div>
-                                    </div>
-                                    {include errors $form['variableSymbol']}
-                                </div>
-                            </div>
-                            <div class="col-md-6">
-                                <div class="form-group ml-2">
-                                    <label n:name="constantSymbol"/>
-                                    <small class="text-muted">volitelný</small>
-                                    {include control $form['constantSymbol'], 'w-50'}
-                                    {include errors $form['constantSymbol']}
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="form-group">
-                            <label n:name="note"/>
-                            <small class="text-muted">volitelná</small>
-                            {include control $form['note']}
-                            {include errors $form['note']}
-                        </div>
-
-                        <input n:name="send" class="btn btn-primary btn-lg w-100 mt-2 ajax">
-                    </form>
-                {/if}
+            <div class="form-group">
+                <label n:name="email"/>
+                <small class="text-muted">volitelný</small>
+                {include control $form['email']}
+                {include errors $form['email']}
             </div>
-        </div>
-    </div>
-</div>
+
+            <div class="form-group">
+                <label n:name="amount"/>
+                <div class="input-group w-50">
+                    {include control $form['amount']}
+                    <div class="input-group-append">
+                        <div class="input-group-text">
+                            Kč
+                        </div>
+                    </div>
+                </div>
+                {include errors $form['amount']}
+            </div>
+
+            <div class="form-group">
+                <label n:name="dueDate"/>
+                <div class="input-group w-50">
+                    <div class="input-group-prepend">
+                        <div class="input-group-text">
+                            <i class="far fa-calendar"></i>
+                        </div>
+                    </div>
+                    {include control $form['dueDate'], 'date'}
+                </div>
+                {include errors $form['dueDate']}
+            </div>
+
+            <div class="row">
+                <div class="col-md-6 pr-0">
+                    <div class="form-group">
+                        <label n:name="variableSymbol"/>
+                        <small class="text-muted">volitelný</small>
+                        <div class="input-group">
+                            {include control $form['variableSymbol']}
+                            <div class="input-group-append"
+                                 title="Předvyplněná hodnota je dosavadní nejvyšší hodnota +1"
+                                 data-toggle="tooltip">
+                                <div class="input-group-text">
+                                    <i class="fas fa-info-circle hidden-xs hidden-sm"></i>
+                                </div>
+                            </div>
+                        </div>
+                        {include errors $form['variableSymbol']}
+                    </div>
+                </div>
+                <div class="col-md-6">
+                    <div class="form-group ml-2">
+                        <label n:name="constantSymbol"/>
+                        <small class="text-muted">volitelný</small>
+                        {include control $form['constantSymbol'], 'w-50'}
+                        {include errors $form['constantSymbol']}
+                    </div>
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label n:name="note"/>
+                <small class="text-muted">volitelná</small>
+                {include control $form['note']}
+                {include errors $form['note']}
+            </div>
+
+            <input n:name="send" class="btn btn-primary btn-lg w-100 mt-2 ajax">
+        </form>
+    {/if}
+{/block}
+
+{block dialog-footer}{/block}

--- a/app/AccountancyModule/PaymentModule/components/templates/RemoveGroupDialog.latte
+++ b/app/AccountancyModule/PaymentModule/components/templates/RemoveGroupDialog.latte
@@ -1,19 +1,8 @@
-<div n:snippet n:inner-if="$renderModal" class="modal" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header text-danger">
-                <h5 class="modal-title">Smazat skupinu plateb</h5>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <div class="modal-body">
-                Tato akce je nevratná. Opravdu chcete smazat skupinu <strong>{$groupName}</strong>?
-                {control form}
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-light" data-dismiss="modal">Storno</button>
-            </div>
-        </div>
-    </div>
-</div>
+{layout $layout}
+
+{block dialog-title}Smazat skupinu plateb{/block}
+
+{block dialog-body}
+    Tato akce je nevratná. Opravdu chcete smazat skupinu <strong>{$groupName}</strong>?
+    {control form}
+{/block}

--- a/app/AccountancyModule/PaymentModule/components/templates/SmtpUpdateForm.latte
+++ b/app/AccountancyModule/PaymentModule/components/templates/SmtpUpdateForm.latte
@@ -1,13 +1,9 @@
-<div n:snippet n:inner-if="$renderModal" class="modal {if $renderModal}rendered{/if}" tabindex="-1">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true"> &times; </span></button>
-                <h4 class="modal-title">Změna hesla</h4>
-            </div>
-            <div class="modal-body">
-                {control form}
-            </div>
-        </div>
-    </div>
-</div>
+{layout $layout}
+
+{block dialog-title}Změna hesla{/block}
+
+{block dialog-body}
+    {control form}
+{/block}
+
+{block dialog-footer}{/block}

--- a/app/AccountancyModule/TravelModule/Components/EditTravelDialog.php
+++ b/app/AccountancyModule/TravelModule/Components/EditTravelDialog.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\AccountancyModule\TravelModule\Components;
 
-use App\AccountancyModule\Components\BaseControl;
+use App\AccountancyModule\Components\Dialog;
 use App\Forms\BaseForm;
 use Assert\Assertion;
 use Model\Travel\Travel\TransportType;
@@ -14,19 +14,14 @@ use Nette\Application\UI\Form;
 use Nette\Utils\ArrayHash;
 use function assert;
 
-final class EditTravelDialog extends BaseControl
+final class EditTravelDialog extends Dialog
 {
     /** @var int|null @persistent */
     public $travelId;
 
-    /** @var bool @persistent */
-    public $opened = false;
+    private int $commandId;
 
-    /** @var int */
-    private $commandId;
-
-    /** @var TravelService */
-    private $model;
+    private TravelService $model;
 
     public function __construct(int $commandId, TravelService $model)
     {
@@ -38,18 +33,13 @@ final class EditTravelDialog extends BaseControl
     public function open(int $travelId) : void
     {
         $this->travelId = $travelId;
-        $this->opened   = true;
-        $this->redrawControl();
+
+        $this->show();
     }
 
-    public function render() : void
+    protected function beforeRender() : void
     {
         $this->template->setFile(__DIR__ . '/templates/EditTravelDialog.latte');
-        $this->template->setParameters([
-            'renderModal' => $this->opened,
-        ]);
-
-        $this->template->render();
     }
 
     protected function createComponentForm() : BaseForm
@@ -79,7 +69,7 @@ final class EditTravelDialog extends BaseControl
             ->addRule(Form::MIN, 'Vzdálenost musí být větší než 0.', 0.01);
 
         $form->addSubmit('send', 'Upravit')
-            ->setAttribute('class', 'btn btn-primary');
+            ->setAttribute('class', 'btn btn-primary ajax');
 
         $travelId = $this->travelId;
         Assertion::notNull($travelId);
@@ -117,6 +107,6 @@ final class EditTravelDialog extends BaseControl
         );
 
         $this->flashMessage('Cesta byla upravena.');
-        $this->redirect('this');
+        $this->hide();
     }
 }

--- a/app/AccountancyModule/TravelModule/Components/templates/EditTravelDialog.latte
+++ b/app/AccountancyModule/TravelModule/Components/templates/EditTravelDialog.latte
@@ -1,17 +1,7 @@
-<div n:snippet n:inner-if="$renderModal" class="modal {if $renderModal}rendered{/if}" tabindex="-1">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span>
-                </button>
-                <h4 class="modal-title">Upravit cestu</h4>
-            </div>
-            <div class="modal-body">
-                {control form}
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-default" data-dismiss="modal">Storno</button>
-            </div>
-        </div>
-    </div>
-</div>
+{layout $layout}
+
+{block dialog-title}Upravit cestu{/block}
+
+{block dialog-body}
+    {control form}
+{/block}

--- a/tests/_support/Page/Payment.php
+++ b/tests/_support/Page/Payment.php
@@ -69,7 +69,7 @@ class Payment
 
     public function submitPayment() : void
     {
-        $this->tester->click('Přidat platbu', '.modal-dialog');
+        $this->tester->click('Přidat platbu', '.modal-footer');
         $this->tester->waitForElementNotVisible('.modal-dialog');
         $this->tester->wait(3);
         $this->tester->waitForElementClickable('(//a[text()=\'Přidat platbu\'])');


### PR DESCRIPTION
V aplikaci máme docela dost modálů, které si však vždy implementují životní cyklus dialogu (zobrazování x skrývání). Pokusil jsem se to dostat na jedno místo.

---

Ty změny jsou v podstatě snadný - vznikla nová šablona Dialog.layout.latte ve které je normální bootstrap modál, kterej má obsah .modal-body, .modal-title, .modal-footer jako bloky dialog-body, dialog-title, resp. dialog-footer.

Takže všechny dialogy (z nového designu), které předtím vypadaly:
```latte
<div n:snippet n:inner-if="$renderModal" class="modal" tabindex="-1" role="dialog">
    <div class="modal-dialog" role="document">
        <div class="modal-content">
            <div class="modal-header">
                <h5 class="modal-title">Nějaký titulek</h5>
                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                    <span aria-hidden="true">&times;</span>
                </button>
            </div>
            <div class="modal-body">Nějaký obsah</div>
            <div class="modal-footer">Nějaký footer</div>
        </div>
    </div>
</div>
```

Teď vypadají takto:
```latte
{layout $layout}

{block dialog-title}Nějaký titulek{/block}
{block dialog-body}Nějaký obsah{/block}
{block dialog-footer}Nějaký footer{/block}
```