### PR TITLE
Sloučení exportovacích tlačítek pro pokladní knihu

### DIFF
--- a/app/AccountancyModule/Components/Cashbook/templates/ChitListControl.topPanel.latte
+++ b/app/AccountancyModule/Components/Cashbook/templates/ChitListControl.topPanel.latte
@@ -3,40 +3,38 @@
     Dogenerovat čísla dokladů
 </a>
 
-<a n:if="! $cashbookType->isUnit() && count($chits) !== 0"
-        href="{plink :Accountancy:CashbookExport:printCashbook $cashbookId, $paymentMethod->toString ()}" target="_blank" class="btn btn-sm btn-info mb-2">
-    <i class="fas fa-print d-none d-lg-inline"></i>
-    {if $paymentMethod->equalsValue('cash')}
-        Vytisknout <span class="d-none d-lg-inline">pokladní knihu</span>
-    {else}
-        Vytisknout bankovní transakce
-    {/if}
-</a>
 
 <div class="btn-group mb-2">
     <div class="dropdown">
         <button class="btn btn-sm btn-info dropdown-toggle"
                 type="button"
-                id="excelExportButton"
+                id="exportButton"
                 data-toggle="dropdown"
                 aria-haspopup="true"
                 aria-expanded="false">
-            <i class="fas fa-table d-none d-lg-inline"></i>&nbsp;Exportovat do excelu&nbsp;<span class="caret"></span>
+            Exporty<span class="caret"></span>
         </button>
 
-        <ul class="dropdown-menu" aria-labelledby="excelExportButton">
-            <li>
-                <a class="dropdown-item"
-                   href="{plink :Accountancy:CashbookExport:exportCashbook $cashbookId, $paymentMethod->toString()}">
-                    Jednoduchá šablona
-                </a>
-            </li>
-            <li>
-                <a class="dropdown-item"
-                   href="{plink :Accountancy:CashbookExport:exportCashbookWithCategories $cashbookId, $paymentMethod->toString()}">
-                    Šablona s rozepsanými kategoriemi
-                </a>
-            </li>
+        <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="exportButton">
+            <a n:class="dropdown-item, count($chits) === 0 ? disabled"
+                    n:if="! $cashbookType->isUnit()"
+                    href="{plink :Accountancy:CashbookExport:printCashbook $cashbookId, $paymentMethod->toString ()}" target="_blank">
+                <i class="far fa-file-pdf"></i>
+                {if $paymentMethod->equalsValue('cash')}
+                    Pokladní kniha.pdf
+                {else}
+                    Bankovní transakce.pdf
+                {/if}
+            </a>
+            <div class="dropdown-divider"></div>
+            <a n:class="dropdown-item, count($chits) === 0 ? disabled"
+               href="{plink :Accountancy:CashbookExport:exportCashbook $cashbookId, $paymentMethod->toString()}">
+                <i class="far fa-file-excel"></i> Pokladní kniha.xlsx
+            </a>
+            <a n:class="dropdown-item, count($chits) === 0 ? disabled"
+               href="{plink :Accountancy:CashbookExport:exportCashbookWithCategories $cashbookId, $paymentMethod->toString()}">
+                <i class="far fa-file-excel"></i> Pokladní kniha rozšířená.xlsx
+            </a>
         </ul>
     </div>
 </div>


### PR DESCRIPTION
# Původně
<img width="948" alt="Screenshot 2020-04-24 at 10 32 15" src="https://user-images.githubusercontent.com/1140123/80192039-e190ff00-8616-11ea-8117-bb0bcf736be4.png">

<img width="958" alt="Screenshot 2020-04-24 at 10 32 39" src="https://user-images.githubusercontent.com/1140123/80192071-eeadee00-8616-11ea-9afb-8974341dd59b.png">

# Nově
<img width="845" alt="Screenshot 2020-04-24 at 10 33 41" src="https://user-images.githubusercontent.com/1140123/80192168-13a26100-8617-11ea-9315-eca00cc8528c.png">

<img width="854" alt="Screenshot 2020-04-24 at 10 28 36" src="https://user-images.githubusercontent.com/1140123/80192181-17ce7e80-8617-11ea-88fb-958d98b5e67d.png">
