### PR TITLE
Oprava počítání plateb bez odeslaného emailu

### DIFF
--- a/app/AccountancyModule/PaymentModule/presenters/PaymentPresenter.php
+++ b/app/AccountancyModule/PaymentModule/presenters/PaymentPresenter.php
@@ -138,6 +138,7 @@ class PaymentPresenter extends BasePresenter
             'summarize' => $this->model->getGroupSummaries([$id])[$id],
             'now'       => new DateTimeImmutable(),
             'isGroupSendActive' => $group->getState() === 'open' && ! empty($paymentsForSendEmail),
+            'notSentPaymentsCount' => $this->countNotSentPayments($payments),
         ]);
     }
 
@@ -429,5 +430,13 @@ class PaymentPresenter extends BasePresenter
                 return ! $p->isClosed() && $p->getEmail() !== null && $p->getSentEmails() === [];
             }
         );
+    }
+
+    /**
+     * @param Payment[] $payments
+     */
+    private function countNotSentPayments(array $payments) : int
+    {
+        return count(array_filter($payments, fn (Payment $payment) => $payment->getSentEmails() === []));
     }
 }

--- a/app/AccountancyModule/PaymentModule/templates/Payment/default.latte
+++ b/app/AccountancyModule/PaymentModule/templates/Payment/default.latte
@@ -34,14 +34,13 @@
         </div>
 </div>
 
-{var $preparingCount = $summarize['preparing']->count}
-<div class="alert alert-warning mt-3 text-center" n:if="$preparingCount !== 0">
+<div class="alert alert-warning mt-3 text-center" n:if="$notSentPaymentsCount !== 0">
     <i class="fas fa-exclamation-triangle"></i>
-    {$preparingCount}
-    {if $preparingCount === 1}nezaplacená platba nemá
-    {elseif $preparingCount < 4}nezaplacené platby
-    {else}nezaplacených plateb nemá{/if}
-    odeslány platební údaje
+    {$notSentPaymentsCount}
+    {if notSentPaymentsCount === 1}nezaplacená platba nemá odeslány
+    {elseif $notSentPaymentsCount < 4}nezaplacené platby nemají odeslány
+    {else}nezaplacených plateb nemá odesláno{/if}
+    platební údaje
 </div>
 <div class="mb-3">
     <div class="mt-4 d-lg-flex" n:inner-if="$isEditable && $group->state === 'open'">


### PR DESCRIPTION
Tohle je pozůstatek stavu `odesláno` u plateb. Zobrazovali jsme v UI počet všech plateb, které byly ve stavu `připravena`, abychom uživatele upozornili, že má ještě rozeslat emaily.

Každopádně s tím, jak jsem předělal odesílání mailů tak, že momentálně platby zůstávají ve stavu `připravena` a emaily se evidují jako kolekce u plateb, došlo k tomu, že to číslo v UI nesedělo - počítalo všechny `připravené` platby jako neodeslané.