### PR TITLE
Oprava kontoly částky u platby

### DIFF
--- a/app/AccountancyModule/PaymentModule/components/MassAddForm.php
+++ b/app/AccountancyModule/PaymentModule/components/MassAddForm.php
@@ -109,10 +109,10 @@ class MassAddForm extends BaseControl
             ->setNullable()
             ->setDefaultValue($amount)
             ->addConditionOn($selected, $form::FILLED)
-            ->addConditionOn($defaultAmount, $form::BLANK)
-            ->setRequired('Musíte vyplnit částku')
             ->addRule($form::FLOAT, 'Částka musí být číslo')
-            ->addRule($form::MIN, 'Čátka musí být větší než 0', 0.01);
+            ->addRule($form::MIN, 'Čátka musí být větší než 0', 0.01)
+            ->addConditionOn($defaultAmount, $form::BLANK)
+            ->setRequired('Musíte vyplnit částku');
 
         $container->addDate('dueDate', 'Splatnost:')
             ->disableWeekends()


### PR DESCRIPTION
V případě, že je zadaná výchozí částka, tak lze zadat 0 jako platbu a to pak následně vychodí chybu na neplatný argent, že amount má být větší než 0. 

<img width="593" alt="Screenshot 2020-05-31 at 22 42 18" src="https://user-images.githubusercontent.com/1140123/83362241-fd16c480-a38f-11ea-8838-44a2156c808a.png">
