### PR TITLE
Oprava chybného názvu sloupce

### DIFF
--- a/app/model/Excel/ExcelService.php
+++ b/app/model/Excel/ExcelService.php
@@ -106,7 +106,7 @@ class ExcelService
         $sheet->setCellValue('A1', 'P.č.')
             ->setCellValue('B1', 'Jméno')
             ->setCellValue('C1', 'Příjmení')
-            ->setCellValue('D1', 'Příjmení')
+            ->setCellValue('D1', 'Přezdívka')
             ->setCellValue('E1', 'Ulice')
             ->setCellValue('F1', 'Město')
             ->setCellValue('G1', 'PSČ')


### PR DESCRIPTION
Při exportu seznamu účastníků tábora byl sloupec obsahující přezdívky účastníků nadepsán *Příjmení*, místo *Přezdívka*.