### PR TITLE
Oprava failujících akceptačních testů po přístupu na přihlašovací stránku

### DIFF
--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -45,7 +45,7 @@ class AcceptanceTester extends Actor
 
         $I->amOnPage('/');
         $I->click('Přihlásit se');
-        $I->see('přihlášení');
+        $I->waitForText('přihlášení');
         $I->fillField('(//input)[9]', self::LOGIN);
         $I->fillField('(//input)[10]', self::PASSWORD);
         $I->click('//button');


### PR DESCRIPTION
Momentálně se zdá, že akceptační testy občas běží natolik rychle, že se pokusí ve Skautisu hledat text přihlášení ještě předtím než se načte ten webfont. Takže ten tester nevidí daným text a failne.

P.S. On je to teda i "fail" Skautisu, že nemá fallback na standardní font, takže na pomalém připojení nejdřív problikne obrazovka kompletně bez textů.

Tohle by mělo fixnout (alespoň část z nich) situace, kdy akceptační testy náhodně padají.

 ![image](https://user-images.githubusercontent.com/5658260/95184965-638d7280-07c8-11eb-90c4-64484e2a6eed.png)