### PR TITLE
Umožnit více příjemců emailů u plateb

### DIFF
--- a/app/AccountancyModule/MyValidators.php
+++ b/app/AccountancyModule/MyValidators.php
@@ -7,13 +7,19 @@ namespace App;
 use DateTimeInterface;
 use Nette\Forms\Controls\MultiChoiceControl;
 use Nette\StaticClass;
+use Nette\Utils\Validators;
 use Nextras\Forms\Controls\DatePicker;
 use function array_intersect;
 use function count;
+use function explode;
+use function preg_replace;
+use function trim;
 
 class MyValidators
 {
     use StaticClass;
+
+    public const EMAIL_SEPARATOR = ',';
 
     /**
      * @param mixed $control
@@ -34,5 +40,20 @@ class MyValidators
     public static function hasSelectedAny(MultiChoiceControl $control, array $values) : bool
     {
         return count(array_intersect($control->getValue(), $values)) !== 0;
+    }
+
+    /**
+     * @param mixed $control
+     */
+    public static function isValidEmailList($control) : bool
+    {
+        $value = preg_replace('/\s+/', '', $control->value);
+        foreach (explode(self::EMAIL_SEPARATOR, $value) as $email) {
+            if (! Validators::isEmail(trim($email))) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/app/AccountancyModule/PaymentModule/components/MassAddForm.php
+++ b/app/AccountancyModule/PaymentModule/components/MassAddForm.php
@@ -8,6 +8,7 @@ use App\AccountancyModule\Components\BaseControl;
 use App\Forms\BaseContainer;
 use App\Forms\BaseForm;
 use eGen\MessageBus\Bus\CommandBus;
+use Model\Common\EmailAddress;
 use Model\Payment\Commands\Payment\CreatePayment;
 use Model\PaymentService;
 use Nette\Forms\Controls\TextBase;
@@ -93,7 +94,7 @@ class MassAddForm extends BaseControl
 
         $selected = $container->addCheckbox('selected');
 
-        $container->addSelect('email', null, $emails)
+        $container->addMultiSelect('email', null, $emails)
             ->setRequired(false);
 
         $container->addText('name')
@@ -177,7 +178,7 @@ class MassAddForm extends BaseControl
                 new CreatePayment(
                     $this->groupId,
                     $person->name,
-                    $person->email,
+                    [new EmailAddress($person->email)],
                     (float) ($person->amount ?? $values->amount),
                     $person->dueDate ?? $values->dueDate,
                     (int) $person->id,

--- a/app/AccountancyModule/PaymentModule/components/templates/MassAddForm.latte
+++ b/app/AccountancyModule/PaymentModule/components/templates/MassAddForm.latte
@@ -24,7 +24,7 @@
         <tr n:foreach="$form['persons']->getComponents() as $container">
             <td class="dependent-checkbox"><input n:name="$container['selected']"></td>
             <td>{input $container["name"], class=>"input-sm form-control"}</td>
-            <td>{input $container["email"], class=>"input-sm form-control"}</td>
+            <td>{input $container["email"], class=>"input-sm form-control",  size=>2}</td>
             <td>{input $container["amount"], class=>"input-sm form-control"}</td>
             <td>{input $container["dueDate"], class=>"input-sm form-control date"}</td>
             <td>{input $container["variableSymbol"], class=>"input-sm form-control"}</td>

--- a/app/AccountancyModule/PaymentModule/components/templates/PaymentDialog.latte
+++ b/app/AccountancyModule/PaymentModule/components/templates/PaymentDialog.latte
@@ -24,6 +24,9 @@
             <div class="form-group">
                 <label n:name="email"/>
                 <small class="text-muted">volitelný</small>
+                <span title="Pro více příjemců, oddělte jejich emailové adresy čárkou" data-toggle="tooltip">
+                        <i class="fas fa-info-circle hidden-xs hidden-sm"></i>
+                </span>
                 {include control $form['email']}
                 {include errors $form['email']}
             </div>

--- a/app/AccountancyModule/PaymentModule/components/templates/PaymentList.grid.latte
+++ b/app/AccountancyModule/PaymentModule/components/templates/PaymentList.grid.latte
@@ -44,7 +44,9 @@
 {/block}
 
 {block col-email}
-    <span class="small">{$item->getEmail()}</span>
+    <span class="small" n:inner-foreach="$item->getEmailRecipients() as $recipient">
+        {$recipient|truncate:35}{if !$iterator->isLast()}, {/if}
+    </span>
 {/block}
 
 {block col-actions}
@@ -53,8 +55,8 @@
            class="btn btn-sm btn-secondary ajax"
            title="Upravit platbu"><i class="far fa-edit"></i></a>
         <a href="{plink send! $item->id}"
-                n:class="btn, btn-sm, btn-primary, $item->getEmail() !== null ? 'ui--sendEmail', $item->getEmail() === NULL ? disabled"
-           title="{$item->getEmail() === NULL ? 'Není uveden email' : 'Odeslat email o platbě'}"><i
+                n:class="btn, btn-sm, btn-primary, !empty($item->getEmailRecipients()) ? 'ui--sendEmail', empty($item->getEmailRecipients()) ? disabled"
+           title="{empty($item->getEmailRecipients()) ? 'Není uveden email' : 'Odeslat email o platbě'}"><i
                     class="far fa-envelope-open"></i></a>
         <a href="{plink complete! $item->getId()}" class="btn btn-sm btn-success" title="Zaplaceno"><i
                     class="fas fa-check"></i></a>

--- a/app/AccountancyModule/PaymentModule/presenters/PaymentPresenter.php
+++ b/app/AccountancyModule/PaymentModule/presenters/PaymentPresenter.php
@@ -198,7 +198,7 @@ class PaymentPresenter extends BasePresenter
             $this->redirect('this');
         }
 
-        if ($payment->getEmail() === null) {
+        if (empty($payment->getEmailRecipients())) {
             $this->flashMessage('Platba nemá vyplněný email', 'danger');
             $this->redirect('this');
         }
@@ -419,7 +419,7 @@ class PaymentPresenter extends BasePresenter
         return array_filter(
             $payments,
             function (Payment $p) {
-                return ! $p->isClosed() && $p->getEmail() !== null && $p->getSentEmails() === [];
+                return ! $p->isClosed() && ! empty($p->getEmailRecipients()) && $p->getSentEmails() === [];
             }
         );
     }

--- a/app/config/model/doctrine.neon
+++ b/app/config/model/doctrine.neon
@@ -57,6 +57,9 @@ dbal:
             transport_types:
                 class: Model\Infrastructure\Types\TransportTypeListType
                 commented: true
+            email_address:
+                class: Model\Infrastructure\Types\EmailAddressType
+                commented: true
 
 services:
     - Model\Infrastructure\EntityManagerFactory(%debugMode%, %tempDir%)

--- a/app/model/DTO/Payment/EmailAddress.php
+++ b/app/model/DTO/Payment/EmailAddress.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Model\Common;
+
+use InvalidArgumentException;
+use Nette\Utils\Validators;
+use function sprintf;
+use function trim;
+
+final class EmailAddress
+{
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        $value = trim($value);
+        if (! Validators::isEmail($value)) {
+            throw new InvalidArgumentException(sprintf("Value '%s' is not valid email!", $value));
+        }
+        $this->value = $value;
+    }
+
+    public function getValue() : string
+    {
+        return $this->value;
+    }
+
+    public function __toString() : string
+    {
+        return $this->getValue();
+    }
+}

--- a/app/model/DTO/Payment/Payment.php
+++ b/app/model/DTO/Payment/Payment.php
@@ -6,6 +6,7 @@ namespace Model\DTO\Payment;
 
 use Cake\Chronos\Date;
 use DateTimeImmutable;
+use Model\Common\EmailAddress;
 use Model\Payment\Payment\SentEmail;
 use Model\Payment\Payment\State;
 use Model\Payment\Payment\Transaction;
@@ -16,7 +17,7 @@ use Nette\SmartObject;
  * @property-read int $id
  * @property-read string $name
  * @property-read float $amount
- * @property-read string|NULL $email
+ * @property-read EmailAddress[] $recipients
  * @property-read Date $dueDate
  * @property-read VariableSymbol|NULL $variableSymbol
  * @property-read int|NULL $constantSymbol
@@ -33,62 +34,49 @@ class Payment
 {
     use SmartObject;
 
-    /** @var int */
-    private $id;
+    private int $id;
 
-    /** @var string */
-    private $name;
+    private string $name;
 
-    /** @var float */
-    private $amount;
+    private float $amount;
 
-    /** @var string|NULL */
-    private $email;
+    /** @var EmailAddress[]  */
+    private array $recipients;
 
-    /** @var Date */
-    private $dueDate;
+    private Date $dueDate;
 
-    /** @var VariableSymbol|NULL */
-    private $variableSymbol;
+    private ?VariableSymbol $variableSymbol;
 
-    /** @var int|NULL */
-    private $constantSymbol;
+    private ?int $constantSymbol;
 
-    /** @var string */
-    private $note;
+    private string $note;
 
-    /** @var bool */
-    private $closed;
+    private bool $closed;
 
-    /** @var State */
-    private $state;
+    private State $state;
 
-    /** @var Transaction|NULL */
-    private $transaction;
+    private ?Transaction $transaction;
 
-    /** @var DateTimeImmutable|NULL */
-    private $closedAt;
+    private ?DateTimeImmutable $closedAt;
 
-    /** @var string|NULL */
-    private $closedByUsername;
+    private ?string $closedByUsername;
 
-    /** @var int|NULL */
-    private $personId;
+    private ?int $personId;
 
-    /** @var int */
-    private $groupId;
+    private int $groupId;
 
     /** @var SentEmail[] */
-    private $sentEmails;
+    private array $sentEmails;
 
     /**
-     * @param SentEmail[] $sentEmails
+     * @param EmailAddress[] $recipients
+     * @param SentEmail[]    $sentEmails
      */
     public function __construct(
         int $id,
         string $name,
         float $amount,
-        ?string $email,
+        array $recipients,
         Date $dueDate,
         ?VariableSymbol $variableSymbol,
         ?int $constantSymbol,
@@ -105,7 +93,7 @@ class Payment
         $this->id               = $id;
         $this->name             = $name;
         $this->amount           = $amount;
-        $this->email            = $email;
+        $this->recipients       = $recipients;
         $this->dueDate          = $dueDate;
         $this->variableSymbol   = $variableSymbol;
         $this->constantSymbol   = $constantSymbol;
@@ -135,9 +123,10 @@ class Payment
         return $this->amount;
     }
 
-    public function getEmail() : ?string
+    /** @return EmailAddress[] */
+    public function getEmailRecipients() : array
     {
-        return $this->email;
+        return $this->recipients;
     }
 
     public function getDueDate() : Date

--- a/app/model/DTO/Payment/PaymentFactory.php
+++ b/app/model/DTO/Payment/PaymentFactory.php
@@ -7,6 +7,7 @@ namespace Model\DTO\Payment;
 use Cake\Chronos\Date;
 use Model\DTO\Payment\Payment as PaymentDTO;
 use Model\Payment\Payment;
+use function array_map;
 
 class PaymentFactory
 {
@@ -16,7 +17,7 @@ class PaymentFactory
             $payment->getId(),
             $payment->getName(),
             $payment->getAmount(),
-            $payment->getEmail(),
+            array_map(fn(Payment\EmailRecipient $recipient) => $recipient->getEmailAddress(), $payment->getEmailRecipients()),
             Date::instance($payment->getDueDate()),
             $payment->getVariableSymbol(),
             $payment->getConstantSymbol(),

--- a/app/model/Infrastructure/Types/EmailAddressType.php
+++ b/app/model/Infrastructure/Types/EmailAddressType.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Model\Infrastructure\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\StringType;
+use Model\Common\EmailAddress;
+
+class EmailAddressType extends StringType
+{
+    public function getName() : string
+    {
+        return 'email_address';
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform) : ?string
+    {
+        /** @var $value EmailAddress */
+        return $value === null ? null : $value->getValue();
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform) : ?EmailAddress
+    {
+        return $value === null ? null : new EmailAddress($value);
+    }
+}

--- a/app/model/Payment/Commands/Payment/CreatePayment.php
+++ b/app/model/Payment/Commands/Payment/CreatePayment.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Model\Payment\Commands\Payment;
 
 use Cake\Chronos\Date;
+use Model\Common\EmailAddress;
 use Model\Payment\Handlers\Payment\CreatePaymentHandler;
 use Model\Payment\VariableSymbol;
 
@@ -13,37 +14,32 @@ use Model\Payment\VariableSymbol;
  */
 final class CreatePayment
 {
-    /** @var int */
-    private $groupId;
+    private int $groupId;
 
-    /** @var string */
-    private $name;
+    private string $name;
 
-    /** @var string|null */
-    private $email;
+    /** @var EmailAddress[] */
+    private array $recipients;
 
-    /** @var float */
-    private $amount;
+    private float $amount;
 
-    /** @var Date */
-    private $dueDate;
+    private Date $dueDate;
 
-    /** @var int|null */
-    private $personId;
+    private ?int $personId;
 
-    /** @var VariableSymbol|null */
-    private $variableSymbol;
+    private ?VariableSymbol $variableSymbol;
 
-    /** @var int|null */
-    private $constantSymbol;
+    private ?int $constantSymbol;
 
-    /** @var string */
-    private $note;
+    private string $note;
 
+    /**
+     * @param EmailAddress[] $recipients
+     */
     public function __construct(
         int $groupId,
         string $name,
-        ?string $email,
+        array $recipients,
         float $amount,
         Date $dueDate,
         ?int $personId,
@@ -53,7 +49,7 @@ final class CreatePayment
     ) {
         $this->groupId        = $groupId;
         $this->name           = $name;
-        $this->email          = $email;
+        $this->recipients     = $recipients;
         $this->amount         = $amount;
         $this->dueDate        = $dueDate;
         $this->personId       = $personId;
@@ -72,9 +68,10 @@ final class CreatePayment
         return $this->name;
     }
 
-    public function getEmail() : ?string
+    /** @return EmailAddress[] */
+    public function getRecipients() : array
     {
-        return $this->email;
+        return $this->recipients;
     }
 
     public function getAmount() : float

--- a/app/model/Payment/Commands/Payment/UpdatePayment.php
+++ b/app/model/Payment/Commands/Payment/UpdatePayment.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Model\Payment\Commands\Payment;
 
 use Cake\Chronos\Date;
+use Model\Common\EmailAddress;
 use Model\Payment\VariableSymbol;
 
 final class UpdatePayment
@@ -12,8 +13,8 @@ final class UpdatePayment
     /** @var string */
     private $name;
 
-    /** @var string|null */
-    private $email;
+    /** @var EmailAddress[] */
+    private array $recipients;
 
     /** @var float */
     private $amount;
@@ -33,10 +34,13 @@ final class UpdatePayment
     /** @var int */
     private $paymentId;
 
+    /**
+     * @param EmailAddress[] $recipients
+     */
     public function __construct(
         int $paymentId,
         string $name,
-        ?string $email,
+        array $recipients,
         float $amount,
         Date $dueDate,
         ?VariableSymbol $variableSymbol,
@@ -45,7 +49,7 @@ final class UpdatePayment
     ) {
         $this->paymentId      = $paymentId;
         $this->name           = $name;
-        $this->email          = $email;
+        $this->recipients     = $recipients;
         $this->amount         = $amount;
         $this->dueDate        = $dueDate;
         $this->variableSymbol = $variableSymbol;
@@ -63,9 +67,10 @@ final class UpdatePayment
         return $this->name;
     }
 
-    public function getEmail() : ?string
+    /** @return EmailAddress[] */
+    public function getRecipients() : array
     {
-        return $this->email;
+        return $this->recipients;
     }
 
     public function getAmount() : float

--- a/app/model/Payment/Handlers/Payment/CreatePaymentHandler.php
+++ b/app/model/Payment/Handlers/Payment/CreatePaymentHandler.php
@@ -31,7 +31,7 @@ final class CreatePaymentHandler
             new Payment(
                 $group,
                 $command->getName(),
-                $command->getEmail(),
+                $command->getRecipients(),
                 $command->getAmount(),
                 $command->getDueDate(),
                 $command->getVariableSymbol(),

--- a/app/model/Payment/Handlers/Payment/UpdatePaymentHandler.php
+++ b/app/model/Payment/Handlers/Payment/UpdatePaymentHandler.php
@@ -9,8 +9,7 @@ use Model\Payment\Repositories\IPaymentRepository;
 
 final class UpdatePaymentHandler
 {
-    /** @var IPaymentRepository */
-    private $payments;
+    private IPaymentRepository $payments;
 
     public function __construct(IPaymentRepository $payments)
     {
@@ -23,14 +22,13 @@ final class UpdatePaymentHandler
 
         $payment->update(
             $command->getName(),
-            $command->getEmail(),
+            $command->getRecipients(),
             $command->getAmount(),
             $command->getDueDate(),
             $command->getVariableSymbol(),
             $command->getConstantSymbol(),
             $command->getNote()
         );
-
         $this->payments->save($payment);
     }
 }

--- a/app/model/Payment/Mailing/Payment.php
+++ b/app/model/Payment/Mailing/Payment.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Model\Payment\Mailing;
 
 use DateTimeImmutable;
+use Model\Common\EmailAddress;
 
 class Payment
 {
@@ -14,8 +15,8 @@ class Payment
     /** @var float */
     private $amount;
 
-    /** @var string */
-    private $email;
+    /** @var EmailAddress[] */
+    private array $recipients;
 
     /** @var DateTimeImmutable */
     private $dueDate;
@@ -29,11 +30,14 @@ class Payment
     /** @var string */
     private $note;
 
-    public function __construct(string $name, float $amount, string $email, DateTimeImmutable $dueDate, ?int $variableSymbol, ?int $constantSymbol, string $note)
+    /**
+     * @param EmailAddress[] $recipients
+     */
+    public function __construct(string $name, float $amount, array $recipients, DateTimeImmutable $dueDate, ?int $variableSymbol, ?int $constantSymbol, string $note)
     {
         $this->name           = $name;
         $this->amount         = $amount;
-        $this->email          = $email;
+        $this->recipients     = $recipients;
         $this->dueDate        = $dueDate;
         $this->variableSymbol = $variableSymbol;
         $this->constantSymbol = $constantSymbol;
@@ -50,9 +54,12 @@ class Payment
         return $this->amount;
     }
 
-    public function getEmail() : string
+    /**
+     * @return EmailAddress[]
+     */
+    public function getRecipients() : array
     {
-        return $this->email;
+        return $this->recipients;
     }
 
     public function getDueDate() : DateTimeImmutable

--- a/app/model/Payment/Payment/EmailRecipient.php
+++ b/app/model/Payment/Payment/EmailRecipient.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Model\Payment\Payment;
+
+use Doctrine\ORM\Mapping as ORM;
+use Model\Common\EmailAddress;
+use Model\Payment\Payment;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="pa_payment_email_recipients")
+ */
+class EmailRecipient
+{
+    /**
+     * @ORM\Id()
+     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\Column(type="integer", options={"unsigned"=true})
+     */
+    private int $id;
+
+    /** @ORM\ManyToOne(targetEntity=Payment::class, inversedBy="emailRecipients") */
+    private Payment $payment;
+
+    /**
+     * @ORM\Column(type="email_address")
+     */
+    private EmailAddress $emailAddress;
+
+    public function __construct(Payment $payment, EmailAddress $emailAddress)
+    {
+        $this->payment      = $payment;
+        $this->emailAddress = $emailAddress;
+    }
+
+    public function getPayment() : Payment
+    {
+        return $this->payment;
+    }
+
+    public function getEmailAddress() : EmailAddress
+    {
+        return $this->emailAddress;
+    }
+}

--- a/migrations/2020/Version20201128164940.php
+++ b/migrations/2020/Version20201128164940.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20201128164940 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Allow more recipients for payments';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $this->addSql(<<<'SQL'
+        CREATE TABLE pa_payment_email_recipients (
+            id INT UNSIGNED AUTO_INCREMENT NOT NULL,
+            payment_id INT DEFAULT NULL,
+            email_address VARCHAR(255) NOT NULL COMMENT '(DC2Type:email_address)',
+            INDEX IDX_A3FBD6514C3A3BB (payment_id),
+            PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB
+SQL);
+        $this->addSql('ALTER TABLE pa_payment_email_recipients ADD CONSTRAINT FK_A3FBD6514C3A3BB FOREIGN KEY (payment_id) REFERENCES pa_payment (id)');
+    }
+
+    public function postUp(Schema $schema) : void
+    {
+        $paymentsPairs = $this->connection->fetchAllKeyValue('SELECT id, email FROM pa_payment');
+        foreach ($paymentsPairs as $paymentId => $email) {
+            if ($email === null) {
+                continue;
+            }
+
+            $this->connection->insert('pa_payment_email_recipients', [
+                'payment_id' => $paymentId,
+                'email_address' => $email,
+            ]);
+        }
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->addSql('DROP TABLE pa_payment_email_recipients');
+    }
+}

--- a/tests/integration/Payment/BankServiceTest.php
+++ b/tests/integration/Payment/BankServiceTest.php
@@ -125,7 +125,7 @@ class BankServiceTest extends IntegrationTest
         $payment = new Payment(
             $group,
             Random::generate(),
-            null,
+            [],
             $amount,
             new Date(),
             $variableSymbol === null ? null : new VariableSymbol($variableSymbol),

--- a/tests/integration/Payment/UseCases/LastPairingInvalidationTest.php
+++ b/tests/integration/Payment/UseCases/LastPairingInvalidationTest.php
@@ -58,7 +58,7 @@ final class LastPairingInvalidationTest extends IntegrationTest
         $this->pairPayments();
 
         $this->commandBus->handle(
-            new CreatePayment(1, 'a', null, 2, Helpers::getValidDueDate(), null, new VariableSymbol('1'), null, '')
+            new CreatePayment(1, 'a', [], 2, Helpers::getValidDueDate(), null, new VariableSymbol('1'), null, '')
         );
 
         $this->assertGroupHasEmptyLastPairing();
@@ -76,7 +76,7 @@ final class LastPairingInvalidationTest extends IntegrationTest
             new UpdatePayment(
                 1,
                 'a',
-                null,
+                [],
                 self::ORIGINAL_AMOUNT + 1,
                 Helpers::getValidDueDate(),
                 $originalVariableSymbol,
@@ -100,7 +100,7 @@ final class LastPairingInvalidationTest extends IntegrationTest
             new UpdatePayment(
                 1,
                 'a',
-                null,
+                [],
                 self::ORIGINAL_AMOUNT,
                 Helpers::getValidDueDate(),
                 $originalVariableSymbol->increment(),
@@ -122,7 +122,7 @@ final class LastPairingInvalidationTest extends IntegrationTest
             new UpdatePayment(
                 1,
                 'a',
-                null,
+                [],
                 self::ORIGINAL_AMOUNT,
                 Helpers::getValidDueDate(),
                 null,
@@ -146,7 +146,7 @@ final class LastPairingInvalidationTest extends IntegrationTest
             new UpdatePayment(
                 1,
                 'a',
-                null,
+                [],
                 self::ORIGINAL_AMOUNT + 1,
                 Helpers::getValidDueDate(),
                 $originalVariableSymbol,
@@ -197,7 +197,7 @@ final class LastPairingInvalidationTest extends IntegrationTest
             new CreatePayment(
                 1,
                 'x',
-                null,
+                [],
                 self::ORIGINAL_AMOUNT,
                 Helpers::getValidDueDate(),
                 null,
@@ -212,7 +212,7 @@ final class LastPairingInvalidationTest extends IntegrationTest
             new CreatePayment(
                 1,
                 'x',
-                null,
+                [],
                 self::ORIGINAL_AMOUNT,
                 Helpers::getValidDueDate(),
                 null,

--- a/tests/integration/Payment/UseCases/PaymentCompletedEmailTest.php
+++ b/tests/integration/Payment/UseCases/PaymentCompletedEmailTest.php
@@ -7,6 +7,7 @@ namespace Model\Payment\IntegrationTests;
 use eGen\MessageBus\Bus\CommandBus;
 use Helpers;
 use IntegrationTest;
+use Model\Common\EmailAddress;
 use Model\Common\User;
 use Model\Google\OAuth;
 use Model\Google\OAuthId;
@@ -130,7 +131,7 @@ class PaymentCompletedEmailTest extends IntegrationTest
 
         $this->paymentService->createGroup(11, null, 'Test', $paymentDefaults, $emails, $oAuthId, null);
         $this->commandBus->handle(
-            new CreatePayment(1, 'Platba', $paymentEmail, 100, Helpers::getValidDueDate(), null, null, null, '')
+            new CreatePayment(1, 'Platba', $paymentEmail !== null ? [new EmailAddress($paymentEmail)] : [], 100, Helpers::getValidDueDate(), null, null, null, '')
         );
     }
 

--- a/tests/integration/Payment/UseCases/RemoveGroupTest.php
+++ b/tests/integration/Payment/UseCases/RemoveGroupTest.php
@@ -72,7 +72,7 @@ final class RemoveGroupTest extends IntegrationTest
 
         for ($i = 1; $i <= 3; $i++) {
             $this->payments->save(
-                new Payment($group, 'test' . $i, null, 120, Helpers::getValidDueDate(), null, null, null, '')
+                new Payment($group, 'test' . $i, [], 120, Helpers::getValidDueDate(), null, null, null, '')
             );
         }
 

--- a/tests/integration/PaymentServiceTest.php
+++ b/tests/integration/PaymentServiceTest.php
@@ -71,7 +71,7 @@ class PaymentServiceTest extends IntegrationTest
     private function createPaymentWithoutVariableSymbol(int $groupId) : void
     {
         $this->commandBus->handle(
-            new CreatePayment($groupId, 'test', null, 100, Helpers::getValidDueDate(), null, null, null, '')
+            new CreatePayment($groupId, 'test', [], 100, Helpers::getValidDueDate(), null, null, null, '')
         );
     }
 }

--- a/tests/unit/BankServiceTest.php
+++ b/tests/unit/BankServiceTest.php
@@ -59,7 +59,7 @@ final class BankServiceTest extends Unit
             ->andReturn($transactions);
 
         $payments = [
-            new Payment($group, '-', null, $amount, Date::now(), $vs, null, null, ''),
+            new Payment($group, '-', [], $amount, Date::now(), $vs, null, null, ''),
         ];
 
         Helpers::assignIdentity($payments[0], 1);
@@ -116,8 +116,8 @@ final class BankServiceTest extends Unit
             ->andReturn($transactions1);
 
         $payments1 = [
-            new Payment($group1, '-', null, $amount, Date::now(), $vs1, null, null, ''),
-            new Payment($group2, '-', null, $amount, Date::now(), $vs2, null, null, ''),
+            new Payment($group1, '-', [], $amount, Date::now(), $vs1, null, null, ''),
+            new Payment($group2, '-', [], $amount, Date::now(), $vs2, null, null, ''),
         ];
         Helpers::assignIdentity($payments1[0], 1);
 

--- a/tests/unit/DTO/Payment/EmailAddressTest.php
+++ b/tests/unit/DTO/Payment/EmailAddressTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Model\DTO\Travel\Command;
+
+use Codeception\Test\Unit;
+use InvalidArgumentException;
+use Model\Common\EmailAddress;
+
+class EmailAddressTest extends Unit
+{
+    private const VALID_EMAIL = 'test@gmail.com';
+
+    public function testValidation() : void
+    {
+        $this->assertSame(self::VALID_EMAIL, (new EmailAddress(self::VALID_EMAIL))->getValue());
+
+        $this->assertSame(self::VALID_EMAIL, (new EmailAddress(' ' . self::VALID_EMAIL . ' '))->getValue());
+
+        $this->expectException(InvalidArgumentException::class);
+        new EmailAddress('a.cz');
+    }
+}

--- a/tests/unit/Payment/Group/EmailTemplateTest.php
+++ b/tests/unit/Payment/Group/EmailTemplateTest.php
@@ -7,6 +7,7 @@ namespace Model\Payment\Group;
 use Codeception\Test\Unit;
 use DateTimeImmutable;
 use Mockery as m;
+use Model\Common\EmailAddress;
 use Model\Payment\EmailTemplate;
 use Model\Payment\Group;
 use Model\Payment\Mailing\Payment;
@@ -30,7 +31,7 @@ class EmailTemplateTest extends Unit
 
         $group = m::mock(Group::class);
         $group->shouldReceive('getName')->andReturn('Skupina');
-        $payment = new Payment('František Maša', 200, 'frantisekmasa1@gmail.com', new DateTimeImmutable('2017-04-27'), 4554, 303, 'Poznámka');
+        $payment = new Payment('František Maša', 200, [new EmailAddress('frantisekmasa1@gmail.com')], new DateTimeImmutable('2017-04-27'), 4554, 303, 'Poznámka');
 
         $evaluatedTemplate = $template->evaluate($group, $payment, '123456789/2100', 'Sináček');
 


### PR DESCRIPTION
close #1219

- Užilo by to hezčí UI, ale to bych řešil až časem separátně, aby to neblokovalo funkcionalitu.
- až se to celé ověří v běhu, tak odeberu nepoužívaný email, obdobně jako SMTP. 

## Obecná platba
<img width="508" alt="1obecna" src="https://user-images.githubusercontent.com/1140123/100545921-ba5e7800-325e-11eb-8deb-bf1290e1a710.png">

## Seznam členů
<img width="1129" alt="2list" src="https://user-images.githubusercontent.com/1140123/100545923-bc283b80-325e-11eb-925e-f5d8c57a695a.png">

## Výpis emailů
<img width="582" alt="3result" src="https://user-images.githubusercontent.com/1140123/100545926-bdf1ff00-325e-11eb-8c21-97e981e6865b.png">
