### PR TITLE
Registrace dvou používaných ORM příkazů do konzole

### DIFF
--- a/app/config/model/doctrine.neon
+++ b/app/config/model/doctrine.neon
@@ -61,13 +61,15 @@ dbal:
 services:
     - Model\Infrastructure\EntityManagerFactory(%debugMode%, %tempDir%)
     - @Model\Infrastructure\EntityManagerFactory::create()
-    - Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper
+    - class: Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper
+      tags: { kdyby.console.helper: em }
+
+
+    - Doctrine\ORM\Tools\Console\Command\GenerateProxiesCommand
+    - Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand
 decorator:
     Symfony\Component\Console\Command\Command:
         tags: [ kdyby.console.command ]
-
-    Symfony\Component\Console\Helper\Helper:
-        tags: [ kdyby.console.helper ]
 
     Doctrine\Migrations\Configuration\Configuration:
         setup:


### PR DESCRIPTION
Opravuje https://sentry.io/organizations/skautske-hospodareni-of/issues/2062354608/?project=1328535&referrer=slack

To je command, kterej jsem v appce nenašel, protože se používá jen při deploymentu - tohle tedy opravuje deployment.