### PR TITLE
Defaultní vybrání prvního emailu u hromadného importu plateb

### DIFF
--- a/app/AccountancyModule/PaymentModule/components/MassAddForm.php
+++ b/app/AccountancyModule/PaymentModule/components/MassAddForm.php
@@ -14,7 +14,9 @@ use Model\PaymentService;
 use Nette\Forms\Controls\TextBase;
 
 use function array_filter;
+use function array_keys;
 use function array_map;
+use function array_slice;
 use function assert;
 
 class MassAddForm extends BaseControl
@@ -94,6 +96,7 @@ class MassAddForm extends BaseControl
         $selected = $container->addCheckbox('selected');
 
         $container->addMultiSelect('email', null, $emails)
+            ->setDefaultValue(array_slice(array_keys($emails), 0, 1))
             ->setRequired(false);
 
         $container->addText('name')


### PR DESCRIPTION
Tohle je IMO bug, který vznikl v důsledku přidání možnosti výběru více emailů u platby.

Předtím byl defaultně vybrán první email, teď to není žádný - pro uživatele, který tak používá hskauting jednou ročně pro registrace je to tak změna, která není na první pohled patrná (vanilla multi selectbox není moc uživatelsky známej) a vyústí v to, že si naimportuje platby bez emailů.

Tohle obnovuje chování, které tam bylo předtím - defaultně je vybrán první z emailů. IMO by dávala smysl i varianta automaticky předvybrat všechny, pokud ti to přijde jako lepší varianta @sinacek .  