### PR TITLE
Oprava error reportingu

### DIFF
--- a/app/model/Infrastructure/Log/Sentry/UserContextEventProcessor.php
+++ b/app/model/Infrastructure/Log/Sentry/UserContextEventProcessor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Model\Infrastructure\Log;
 
 use Sentry\Event;
+use Sentry\UserDataBag;
 
 final class UserContextEventProcessor
 {
@@ -20,7 +21,7 @@ final class UserContextEventProcessor
         $userData = $this->userContext->getUserData();
 
         if ($userData !== null) {
-            $event->getUser()->createFromArray($userData);
+            $event->setUser(UserDataBag::createFromArray($userData));
         }
 
         return $event;


### PR DESCRIPTION
Chyba vzniklá při aktualizaci Sentry (#1548) - ten user je defaultně null, takže na něm není možné volat tu továrnu.