### PR TITLE
Odebrání AutoDI

### DIFF
--- a/app/config/components.neon
+++ b/app/config/components.neon
@@ -1,7 +1,3 @@
-autoDI:
-    services:
-        - implement: App\AccountancyModule\**\I*Factory
-
 services:
     # Factories
     - App\AccountancyModule\Factories\GridFactory

--- a/app/config/config.neon
+++ b/app/config/config.neon
@@ -46,48 +46,56 @@ messageBus:
     queryBus:
 
 extensions:
-    autoDI: Fmasa\AutoDI\DI\AutoDIExtension
     skautis: Skautis\Nette\SkautisExtension
     messageBus: eGen\MessageBus\DI\MessageBusExtension
     console: Contributte\Console\DI\ConsoleExtension(%consoleMode%)
 
-autoDI:
-    services:
-        # Main model facades
-        - class: Model\**Service
-          exclude: 'Model\{Event,Chit,Participant}Service' # mutable services
-
-        # Domain services
-        - class: Model\*\Services\**
-
-        # Aggregate repositories
-        - class: Model\Infrastructure\Repositories\**Repository
-
-        # Old repository namespaces - deprecated
-        - class: Model\**\Repositories\*Repository
-
-        # Domain event subscribers
-        - class: Model\*\Subscribers\*Subscriber
-          tags: [eventBus.subscriber]
-
-        # Skautis communication related services
-        - class: Model\Skautis\**
-          exclude:
-              - Model\Skautis\WebserviceFactory
-              - Model\Skautis\ReadModel\Queries\**
-
-        # Utility services
-        - class: Model\Services\**
 search:
     command handlers:
-       in: %appDir%
-       classes: Model\**\Handlers\**Handler
-       tags: [commandBus.handler]
+        in: %appDir%
+        classes: Model\**\Handlers\**Handler
+        tags: [commandBus.handler]
 
     query handlers:
-       in: %appDir%
-       classes: Model\**\ReadModel\**Handler
-       tags: [queryBus.handler]
+        in: %appDir%
+        classes: Model\**\ReadModel\**Handler
+        tags: [queryBus.handler]
+
+    event subscribers:
+        in: %appDir%
+        classes: Model\*\Subscribers\*Subscriber
+        tags: [eventBus.subscriber]
+
+    UI control factories:
+        in: %appDir%
+        classes: App\AccountancyModule\**\I*Factory
+
+    services:
+        in: %appDir%
+        classes:
+            # Main model facades
+            - Model\**Service
+
+            # Domain services
+            - Model\*\Services\**
+
+            # Aggregate repositories
+            - Model\Infrastructure\Repositories\**Repository
+
+            # Old repository namespaces - deprecated
+            - Model\**\Repositories\*Repository
+
+            # Skautis communication related services
+            - Model\Skautis\**
+
+            - Model\Services\**
+        exclude:
+            classes:
+                - Model\Skautis\WebserviceFactory
+                - Model\Skautis\ReadModel\Queries\**
+                - Model\EventService
+                - Model\ChitService
+                - Model\ParticipantService
 
 services:
     skautisCache:

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
         "consistence/consistence-doctrine": "^2.0",
         "contributte/console": "^0.9.0",
         "egen/message-bus": "^2.0",
-        "fmasa/auto-di": "^2.0",
         "fmasa/doctrine-nullable-embeddables": "^1.0",
         "fmasa/sentry-breadcrumbs-monolog-handler": "^2.0",
         "google/apiclient": "^2.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d24f4d834cb9fa6251b3b60bb8fa19ee",
+    "content-hash": "007d3b86e782947152bf2c71f6917ee5",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1929,53 +1929,6 @@
                 "php"
             ],
             "time": "2020-03-25T18:49:23+00:00"
-        },
-        {
-            "name": "fmasa/auto-di",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/fmasa/auto-di.git",
-                "reference": "3687eb4c95d53f4646bb0f29c525c6a7182e8a7c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/fmasa/auto-di/zipball/3687eb4c95d53f4646bb0f29c525c6a7182e8a7c",
-                "reference": "3687eb4c95d53f4646bb0f29c525c6a7182e8a7c",
-                "shasum": ""
-            },
-            "require": {
-                "nette/di": "^3.0",
-                "nette/robot-loader": "^2.4.2 || ^3.0",
-                "php": "^7.1"
-            },
-            "require-dev": {
-                "nette/bootstrap": "^3.0",
-                "phpunit/phpcov": "^3.0",
-                "phpunit/phpunit": "^5.7",
-                "satooshi/php-coveralls": "^1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Fmasa\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "František Maša",
-                    "email": "frantisekmasa1@gmail.com"
-                }
-            ],
-            "support": {
-                "issues": "https://github.com/fmasa/auto-di/issues",
-                "source": "https://github.com/fmasa/auto-di/tree/2.x"
-            },
-            "time": "2020-02-23T15:58:27+00:00"
         },
         {
             "name": "fmasa/doctrine-nullable-embeddables",


### PR DESCRIPTION
Tím, že jsme na Nette 3 už není potřeba používat moje 3rd-party extension a můžeme
pro automatickou registraci služeb použít [SearchExtension](https://doc.nette.org/en/3.0/di-configuration#toc-search), které je přímo součástí `nette/di`.