### PR TITLE
Oprava špatně serializovaného seznamu dopravních prostředků

### DIFF
--- a/app/model/Infrastructure/Types/TransportTypeListType.php
+++ b/app/model/Infrastructure/Types/TransportTypeListType.php
@@ -11,6 +11,7 @@ use Model\Travel\Travel\TransportType;
 use Nette\Utils\Json;
 
 use function array_map;
+use function array_values;
 
 final class TransportTypeListType extends Type
 {
@@ -33,6 +34,7 @@ final class TransportTypeListType extends Type
     public function convertToDatabaseValue($value, AbstractPlatform $platform): string
     {
         Assertion::isArray($value);
+        Assertion::same($value, array_values($value));
         Assertion::allIsInstanceOf($value, TransportType::class);
 
         return Json::encode(array_map(fn (TransportType $type) => $type->toString(), $value));

--- a/app/model/Travel/Command.php
+++ b/app/model/Travel/Command.php
@@ -20,6 +20,7 @@ use Money\Money;
 use function array_reduce;
 use function array_sum;
 use function array_unique;
+use function array_values;
 use function min;
 
 /**
@@ -82,7 +83,7 @@ class Command
     /**
      * @ORM\Column(type="transport_types")
      *
-     * @var TransportType[]
+     * @var list<TransportType>
      */
     private array $transportTypes;
 
@@ -93,7 +94,7 @@ class Command
     private string $unit;
 
     /**
-     * @param TransportType[] $transportTypes
+     * @param list<TransportType> $transportTypes
      */
     public function __construct(
         int $unitId,
@@ -120,12 +121,12 @@ class Command
         $this->note             = $note;
         $this->travels          = new ArrayCollection();
         $this->ownerId          = $ownerId;
-        $this->transportTypes   = array_unique($transportTypes);
+        $this->transportTypes   = array_values(array_unique($transportTypes));
         $this->unit             = $unit;
     }
 
     /**
-     * @param TransportType[] $transportTypes
+     * @param list<TransportType> $transportTypes
      */
     public function update(
         ?Vehicle $vehicle,
@@ -147,7 +148,7 @@ class Command
         $this->fuelPrice        = $fuelPrice;
         $this->amortization     = $amortization;
         $this->note             = $note;
-        $this->transportTypes   = array_unique($transportTypes);
+        $this->transportTypes   = array_values(array_unique($transportTypes));
         $this->unit             = $unit;
     }
 

--- a/app/model/Travel/TravelService.php
+++ b/app/model/Travel/TravelService.php
@@ -29,7 +29,6 @@ use Money\Money;
 
 use function array_map;
 use function array_merge;
-use function array_unique;
 
 class TravelService
 {
@@ -286,7 +285,7 @@ class TravelService
     }
 
     /**
-     * @param TransportType[] $types
+     * @param list<TransportType> $types
      */
     public function addCommand(
         int $unitId,
@@ -326,7 +325,7 @@ class TravelService
     }
 
     /**
-     * @param TransportType[] $types
+     * @param list<TransportType> $types
      */
     public function updateCommand(
         int $id,
@@ -357,7 +356,7 @@ class TravelService
             $fuelPrice,
             $amortization,
             $note,
-            array_unique(array_merge($types, $command->getUsedTransportTypes())),
+            array_merge($types, $command->getUsedTransportTypes()),
             $unit
         );
 


### PR DESCRIPTION
Tohle je obecně častej bug v PHP. Zvážil bych, jestli pak nepřidat třeba Psalm, kterej je schopen rozlišovat mezi `list<T>` jako seznamem a `array<K, V>` jako asociativním polem

Opravuje https://sentry.io/organizations/skautske-hospodareni-of/issues/2788714494/ pro nové záznamy. Aktuální v DB už fixoval @sinacek 