### PR TITLE
Odebrání nepoužívané property `Payment::$email`

### DIFF
--- a/app/model/Payment/Payment.php
+++ b/app/model/Payment/Payment.php
@@ -46,13 +46,6 @@ class Payment extends Aggregate
     /** @ORM\Column(type="string", length=64) */
     private string $name;
 
-   /**
-    * @deprecated - use email recipients
-    *
-    * @ORM\Column(type="text", nullable=true)
-    */
-    private ?string $email;
-
     /**
      * @ORM\OneToMany(targetEntity=EmailRecipient::class, mappedBy="payment", cascade={"persist", "remove"}, orphanRemoval=true)
      *
@@ -227,11 +220,6 @@ class Payment extends Aggregate
     public function getName(): string
     {
         return $this->name;
-    }
-
-    public function getEmail(): ?string
-    {
-        return $this->email;
     }
 
     /**

--- a/migrations/2021/Version20211121182733.php
+++ b/migrations/2021/Version20211121182733.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20211121182733 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Remove unused pa_payment.email column';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE pa_payment DROP email');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE pa_payment ADD email TEXT CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_czech_ci`');
+    }
+}

--- a/tests/integration/Infrastructure/Repositories/Payment/PaymentRepositoryTest.php
+++ b/tests/integration/Infrastructure/Repositories/Payment/PaymentRepositoryTest.php
@@ -27,7 +27,6 @@ class PaymentRepositoryTest extends IntegrationTest
     private const PAYMENT_ROW = [
         'group_id' => 1,
         'name' => 'Test',
-        'email' => 'frantisekmasa1@gmail.com',
         'amount' => 200.0,
         'due_date' => '2017-10-29',
         'note' => '',
@@ -74,7 +73,6 @@ class PaymentRepositoryTest extends IntegrationTest
 
         $this->assertSame($data['group_id'], $payment->getGroupId());
         $this->assertSame($data['name'], $payment->getName());
-        $this->assertSame($data['email'], $payment->getEmail());
         $this->assertSame($data['amount'], $payment->getAmount());
         $this->assertEquals(new Date($data['due_date']), $payment->getDueDate());
         $this->assertTrue($payment->getState()->equalsValue($data['state']), "Payment is not should be 'preparing'");
@@ -162,7 +160,6 @@ class PaymentRepositoryTest extends IntegrationTest
             return [
                 'group_id' => $payment[0],
                 'name' => 'Test',
-                'email' => 'frantisekmasa1@gmail.com',
                 'amount' => $payment[1],
                 'due_date' => '2017-10-29',
                 'note' => '',
@@ -210,7 +207,6 @@ class PaymentRepositoryTest extends IntegrationTest
         $this->tester->haveInDatabase(self::TABLE, [
             'group_id' => 1,
             'name' => 'Test',
-            'email' => 'frantisekmasa1@gmail.com',
             'amount' => 120,
             'due_date' => '2017-10-29',
             'note' => '',


### PR DESCRIPTION
Tohle je pozůstatek z #1517, ta property se nikde nepoužívá a původní data z ní byla přemigrována do té nové entity `EmailRecipient`