### PR TITLE
Aktualizace PHPStan na 1.2

### DIFF
--- a/app/AccountancyModule/EventModule/presenters/CashbookPresenter.php
+++ b/app/AccountancyModule/EventModule/presenters/CashbookPresenter.php
@@ -53,7 +53,9 @@ class CashbookPresenter extends BasePresenter
         $finalBalance     = $this->queryBus->handle(new FinalCashBalanceQuery($this->getCashbookId()));
         $finalRealBalance = $this->queryBus->handle(new FinalRealBalanceQuery($this->getCashbookId()));
 
-        assert(is_float($incomeBalance) && $finalBalance instanceof Money && $finalRealBalance instanceof Money);
+        assert(is_float($incomeBalance));
+        assert($finalBalance instanceof Money);
+        assert($finalRealBalance instanceof Money);
 
         $this->template->setParameters([
             'isCashbookEmpty' => $this->isCashbookEmpty(),

--- a/app/model/Budget/Category.php
+++ b/app/model/Budget/Category.php
@@ -26,7 +26,7 @@ class Category
      */
     private int $id;
 
-    /** @ORM\Column(type="integer", nullable=true) */
+    /** @ORM\Column(type="integer") */
     private int $unitId;
 
     /** @ORM\Column(type="string", length=64) */
@@ -52,7 +52,7 @@ class Category
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="children")
      * @ORM\JoinColumn(name="parentId", referencedColumnName="id")
      */
-    private Category $parent;
+    private ?Category $parent = null;
 
     /** @ORM\Column(type="float", options={"default"=0}) */
     private float $value;

--- a/app/model/Cashbook/Cashbook/Chit.php
+++ b/app/model/Cashbook/Cashbook/Chit.php
@@ -40,7 +40,7 @@ class Chit
 
     /**
      * @ORM\ManyToOne(targetEntity=Cashbook::class, inversedBy="chits")
-     * @ORM\JoinColumn(name="eventId")
+     * @ORM\JoinColumn(name="eventId", nullable=false)
      */
     private Cashbook $cashbook;
 

--- a/app/model/Cashbook/Cashbook/ChitScan.php
+++ b/app/model/Cashbook/Cashbook/ChitScan.php
@@ -24,7 +24,10 @@ class ChitScan
      */
     private int $id;
 
-    /** @ORM\ManyToOne(targetEntity=Chit::class, inversedBy="scans") */
+    /**
+     * @ORM\ManyToOne(targetEntity=Chit::class, inversedBy="scans")
+     * @ORM\JoinColumn(nullable=false)
+     */
     private Chit $chit;
 
     /** @ORM\Column(type="file_path") */

--- a/app/model/Excel/Builders/CashbookWithCategoriesBuilder.php
+++ b/app/model/Excel/Builders/CashbookWithCategoriesBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Model\Excel\Builders;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Model\Cashbook\Cashbook\CashbookId;
 use Model\Cashbook\Cashbook\PaymentMethod;
 use Model\Cashbook\Operation;
@@ -22,7 +23,6 @@ use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 use function array_map;
 use function array_merge;
-use function array_values;
 use function assert;
 use function count;
 use function explode;
@@ -189,9 +189,11 @@ class CashbookWithCategoriesBuilder
             return $category->getOperationType()->equalsValue(Operation::INCOME);
         });
 
-        return array_map(function (ArrayCollection $categories): array {
-            return array_values($categories->toArray()); // partition keeps original keys
-        }, $categoriesByOperation);
+        // partition keeps original keys
+        return array_map(
+            fn (Collection $categories): array => $categories->getValues(),
+            $categoriesByOperation,
+        );
     }
 
     private function addColumnSum(int $column, int $resultRow, int $firstRow): void

--- a/app/model/Payment/Group/Email.php
+++ b/app/model/Payment/Group/Email.php
@@ -23,7 +23,10 @@ class Email
      */
     private int $id;
 
-    /** @ORM\ManyToOne(targetEntity=Group::class, inversedBy="emails") */
+    /**
+     * @ORM\ManyToOne(targetEntity=Group::class, inversedBy="emails")
+     * @ORM\JoinColumn(nullable=false)
+     */
     private Group $group;
 
     /** @ORM\Column(type="boolean") */

--- a/app/model/Payment/Group/Unit.php
+++ b/app/model/Payment/Group/Unit.php
@@ -26,6 +26,7 @@ class Unit
      * @internal for mapping only
      *
      * @ORM\ManyToOne(targetEntity=Group::class, inversedBy="units")
+     * @ORM\JoinColumn(nullable=false)
      */
     private Group $group;
 

--- a/app/model/Payment/Payment/EmailRecipient.php
+++ b/app/model/Payment/Payment/EmailRecipient.php
@@ -21,7 +21,10 @@ class EmailRecipient
      */
     private int $id;
 
-    /** @ORM\ManyToOne(targetEntity=Payment::class, inversedBy="emailRecipients") */
+    /**
+     * @ORM\ManyToOne(targetEntity=Payment::class, inversedBy="emailRecipients")
+     * @ORM\JoinColumn(nullable=false)
+     */
     private Payment $payment;
 
     /** @ORM\Column(type="email_address") */

--- a/app/model/Payment/Payment/SentEmail.php
+++ b/app/model/Payment/Payment/SentEmail.php
@@ -23,7 +23,10 @@ class SentEmail
      */
     private int $id;
 
-    /** @ORM\ManyToOne(targetEntity=Payment::class, inversedBy="sentEmails") */
+    /**
+     * @ORM\ManyToOne(targetEntity=Payment::class, inversedBy="sentEmails")
+     * @ORM\JoinColumn(nullable=false)
+     */
     private Payment $payment;
 
     /**

--- a/app/model/Travel/Command.php
+++ b/app/model/Travel/Command.php
@@ -17,6 +17,7 @@ use Model\Travel\Travel\TransportType;
 use Model\Utils\MoneyFactory;
 use Money\Money;
 
+use function array_filter;
 use function array_reduce;
 use function array_sum;
 use function array_unique;
@@ -255,9 +256,10 @@ class Command
 
     private function getTransportPrice(): Money
     {
-        $prices = $this->travels->filter(function (Travel $t) {
-            return $t instanceof TransportTravel;
-        })->toArray();
+        $prices = array_filter(
+            $this->travels->toArray(),
+            fn (Travel $t) => $t instanceof TransportTravel,
+        );
 
         return array_reduce(
             $prices,

--- a/app/model/Travel/Command.php
+++ b/app/model/Travel/Command.php
@@ -48,7 +48,7 @@ class Command
     /** @ORM\Column(type="string", length=64) */
     private string $purpose;
 
-    /** @ORM\Column(type="string", length=64, nullable=true) */
+    /** @ORM\Column(type="string", length=64) */
     private string $place;
 
     /** @ORM\Column(type="string", length=64) */

--- a/app/model/Travel/Vehicle/RoadworthyScan.php
+++ b/app/model/Travel/Vehicle/RoadworthyScan.php
@@ -25,7 +25,10 @@ class RoadworthyScan
      */
     private int $id;
 
-    /** @ORM\ManyToOne(targetEntity=Vehicle::class, inversedBy="roadworthyScans") */
+    /**
+     * @ORM\ManyToOne(targetEntity=Vehicle::class, inversedBy="roadworthyScans")
+     * @ORM\JoinColumn(nullable=false)
+     */
     private Vehicle $vehicle;
 
     /** @ORM\Column(type="file_path") */

--- a/composer.json
+++ b/composer.json
@@ -59,9 +59,10 @@
         "contributte/codeception": "^1.3.1",
         "doctrine/coding-standard": "^8.2",
         "php-vcr/php-vcr": "^1.4",
-        "phpstan/phpstan": "^0.12.57",
-        "phpstan/phpstan-doctrine": "^0.12.22",
-        "phpstan/phpstan-nette": "^0.12.10",
+        "phpstan/extension-installer": "^1.1",
+        "phpstan/phpstan": "^1.2",
+        "phpstan/phpstan-doctrine": "^1.0",
+        "phpstan/phpstan-nette": "^1.0",
         "roave/security-advisories": "dev-master",
         "squizlabs/php_codesniffer": "^3.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0bb8bd317a8a967090ca6713a92e11fe",
+    "content-hash": "ca2a0feb60582d552ab51d54ae397ea1",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -10555,6 +10555,51 @@
             "time": "2021-09-10T09:02:12+00:00"
         },
         {
+            "name": "phpstan/extension-installer",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "66c7adc9dfa38b6b5838a9fb728b68a7d8348051"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/66c7adc9dfa38b6b5838a9fb728b68a7d8348051",
+                "reference": "66c7adc9dfa38b6b5838a9fb728b68a7d8348051",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1 || ^2.0",
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpstan": ">=0.11.6"
+            },
+            "require-dev": {
+                "composer/composer": "^1.8",
+                "phing/phing": "^2.16.3",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan-strict-rules": "^0.11 || ^0.12"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "support": {
+                "issues": "https://github.com/phpstan/extension-installer/issues",
+                "source": "https://github.com/phpstan/extension-installer/tree/1.1.0"
+            },
+            "time": "2020-12-13T13:06:13+00:00"
+        },
+        {
             "name": "phpstan/phpdoc-parser",
             "version": "0.4.9",
             "source": {
@@ -10601,20 +10646,24 @@
                 "MIT"
             ],
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/master"
+            },
             "time": "2020-08-03T20:32:43+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.80",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "c6a1b17f22ecf708d434d6bee05092647ec7e686"
+                "reference": "cbe085f9fdead5b6d62e4c022ca52dc9427a10ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c6a1b17f22ecf708d434d6bee05092647ec7e686",
-                "reference": "c6a1b17f22ecf708d434d6bee05092647ec7e686",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/cbe085f9fdead5b6d62e4c022ca52dc9427a10ee",
+                "reference": "cbe085f9fdead5b6d62e4c022ca52dc9427a10ee",
                 "shasum": ""
             },
             "require": {
@@ -10630,7 +10679,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.12-dev"
+                    "dev-master": "1.2-dev"
                 }
             },
             "autoload": {
@@ -10643,9 +10692,17 @@
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "source": "https://github.com/phpstan/phpstan/tree/1.2.0"
+            },
             "funding": [
                 {
                     "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
                     "type": "github"
                 },
                 {
@@ -10657,25 +10714,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-28T20:22:43+00:00"
+            "time": "2021-11-18T14:09:01+00:00"
         },
         {
             "name": "phpstan/phpstan-doctrine",
-            "version": "0.12.33",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-doctrine.git",
-                "reference": "b76c21e7b85498399ba4a0147920ff413503e77a"
+                "reference": "ea3919219c4915f4a3896227aaa9e5d3d2034bd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/b76c21e7b85498399ba4a0147920ff413503e77a",
-                "reference": "b76c21e7b85498399ba4a0147920ff413503e77a",
+                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/ea3919219c4915f4a3896227aaa9e5d3d2034bd7",
+                "reference": "ea3919219c4915f4a3896227aaa9e5d3d2034bd7",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0",
-                "phpstan/phpstan": "^0.12.56"
+                "phpstan/phpstan": "^1.0"
             },
             "conflict": {
                 "doctrine/collections": "<1.0",
@@ -10688,21 +10745,22 @@
                 "doctrine/annotations": "^1.11.0",
                 "doctrine/collections": "^1.6",
                 "doctrine/common": "^2.7 || ^3.0",
-                "doctrine/dbal": "^2.11.0",
+                "doctrine/dbal": "^2.13.1",
                 "doctrine/mongodb-odm": "^1.3 || ^2.1",
-                "doctrine/orm": "^2.5",
+                "doctrine/orm": "^2.9.1",
                 "doctrine/persistence": "^1.1 || ^2.0",
-                "phing/phing": "^2.16.3",
+                "nesbot/carbon": "^2.49",
+                "nikic/php-parser": "^4.13.0",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/phpstan-phpunit": "^0.12.16",
-                "phpstan/phpstan-strict-rules": "^0.12.5",
-                "phpunit/phpunit": "^7.5.20",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
                 "ramsey/uuid-doctrine": "^1.5.0"
             },
             "type": "phpstan-extension",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.12-dev"
+                    "dev-master": "1.0-dev"
                 },
                 "phpstan": {
                     "includes": [
@@ -10721,25 +10779,29 @@
                 "MIT"
             ],
             "description": "Doctrine extensions for PHPStan",
-            "time": "2021-03-07T12:28:23+00:00"
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-doctrine/issues",
+                "source": "https://github.com/phpstan/phpstan-doctrine/tree/1.0.1"
+            },
+            "time": "2021-11-02T13:28:55+00:00"
         },
         {
             "name": "phpstan/phpstan-nette",
-            "version": "0.12.17",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-nette.git",
-                "reference": "4930ff18725dd27bf2e15bb2b6ac1ef581d53514"
+                "reference": "f4654b27b107241e052755ec187a0b1964541ba6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-nette/zipball/4930ff18725dd27bf2e15bb2b6ac1ef581d53514",
-                "reference": "4930ff18725dd27bf2e15bb2b6ac1ef581d53514",
+                "url": "https://api.github.com/repos/phpstan/phpstan-nette/zipball/f4654b27b107241e052755ec187a0b1964541ba6",
+                "reference": "f4654b27b107241e052755ec187a0b1964541ba6",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0",
-                "phpstan/phpstan": "^0.12.60"
+                "phpstan/phpstan": "^1.0"
             },
             "conflict": {
                 "nette/application": "<2.3.0",
@@ -10752,17 +10814,17 @@
             "require-dev": {
                 "nette/forms": "^3.0",
                 "nette/utils": "^2.3.0 || ^3.0.0",
-                "phing/phing": "^2.16.3",
+                "nikic/php-parser": "^4.13.0",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/phpstan-php-parser": "^0.12.2",
-                "phpstan/phpstan-phpunit": "^0.12.16",
-                "phpstan/phpstan-strict-rules": "^0.12.5",
-                "phpunit/phpunit": "^7.5.20"
+                "phpstan/phpstan-php-parser": "^1.0",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5"
             },
             "type": "phpstan-extension",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.12-dev"
+                    "dev-master": "1.0-dev"
                 },
                 "phpstan": {
                     "includes": [
@@ -10781,7 +10843,11 @@
                 "MIT"
             ],
             "description": "Nette Framework class reflection extension for PHPStan",
-            "time": "2021-04-11T16:57:55+00:00"
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-nette/issues",
+                "source": "https://github.com/phpstan/phpstan-nette/tree/1.0.0"
+            },
+            "time": "2021-09-20T16:12:57+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/migrations/2021/Version20211121183832.php
+++ b/migrations/2021/Version20211121183832.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20211121183832 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Remove nullability from columns that do not need it';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE ac_chit_scan CHANGE chit_id chit_id INT NOT NULL');
+        $this->addSql('ALTER TABLE ac_chits CHANGE eventId eventId CHAR(36) NOT NULL COMMENT \'(DC2Type:cashbook_id)\'');
+        $this->addSql('ALTER TABLE ac_unit_budget_category CHANGE unit_id unit_id INT NOT NULL');
+        $this->addSql('ALTER TABLE pa_group_email CHANGE group_id group_id INT NOT NULL');
+        $this->addSql('ALTER TABLE pa_group_unit CHANGE group_id group_id INT NOT NULL');
+        $this->addSql('ALTER TABLE pa_payment_email_recipients CHANGE payment_id payment_id INT NOT NULL');
+        $this->addSql('ALTER TABLE pa_payment_sent_emails CHANGE payment_id payment_id INT NOT NULL');
+        $this->addSql('ALTER TABLE tc_commands CHANGE place place VARCHAR(64) NOT NULL');
+        $this->addSql('ALTER TABLE tc_vehicle_roadworthy_scan CHANGE vehicle_id vehicle_id INT NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE ac_chit_scan CHANGE chit_id chit_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE ac_chits CHANGE eventId eventId CHAR(36) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_czech_ci` COMMENT \'(DC2Type:cashbook_id)\'');
+        $this->addSql('ALTER TABLE ac_unit_budget_category CHANGE unit_id unit_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE pa_group_email CHANGE group_id group_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE pa_group_unit CHANGE group_id group_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE pa_payment_email_recipients CHANGE payment_id payment_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE pa_payment_sent_emails CHANGE payment_id payment_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE tc_commands CHANGE place place VARCHAR(64) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_czech_ci`');
+        $this->addSql('ALTER TABLE tc_vehicle_roadworthy_scan CHANGE vehicle_id vehicle_id INT DEFAULT NULL');
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,12 +3,8 @@ parameters:
         # Errors related mostly to usage of assert($x instanceof A || $x === null) and similar asserts
         - '~Unreachable statement - code above always terminates.~'
 
-        # Incompatibility with current PHPStan
-        - '~Return type \(array\<string, mixed\>\) of method Model\\Infrastructure\\Log\\Monolog\\UserContextProcessor\:\:__invoke\(\) should be compatible with return type \(Monolog\\Processor\\Record\) of method Monolog\\Processor\\ProcessorInterface\:\:__invoke\(\)~'
-
-includes:
-    - vendor/phpstan/phpstan-nette/extension.neon
-    - vendor/phpstan/phpstan-doctrine/extension.neon
+    doctrine:
+        objectManagerLoader: tests/object-manager.php
 
 services:
 	- class: CodeQuality\ObjectIdentityComparisonRule
@@ -22,7 +18,7 @@ services:
 
 	- class: CodeQuality\QueryBusDynamicReturnTypeProvider
 	  arguments:
-	      - %autoload_directories%
+	      - [%rootDir%/../../../app]
 	      - %rootDir%/../../../temp
 	      - '~^.*QueryHandlers\\.*Handler$~'
 

--- a/tests/object-manager.php
+++ b/tests/object-manager.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is used by PHPStan to obtain information about Doctrine entities
+ * see https://github.com/phpstan/phpstan-doctrine#configuration
+ */
+
+use Doctrine\Persistence\ObjectManager;
+use Nette\DI\Extensions\ExtensionsExtension;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$tempDir = dirname(__DIR__) . '/temp';
+$logDir  = __DIR__ . '/../log';
+
+putenv('TMPDIR=' . $tempDir);
+
+$configurator = new Nette\Configurator();
+$configurator->setDebugMode(true);
+$configurator->enableDebugger($logDir);
+$configurator->setTempDirectory($tempDir);
+
+$configurator->createRobotLoader()
+    ->addDirectory(__DIR__ . '/../app')
+    ->register(true);
+
+$configurator->defaultExtensions = [
+    'extensions' => ExtensionsExtension::class,
+    'tracy' => [Tracy\Bridges\Nette\TracyExtension::class, ['%debugMode%', '%consoleMode%']],
+];
+
+$configurator->addConfig(__DIR__ . '/integration/config/doctrine.neon');
+
+$configurator->addParameters(['logDir' => $logDir]);
+
+return $configurator->createContainer()->getByType(ObjectManager::class);


### PR DESCRIPTION
Tohle by nedokázal dependabot sám pořešit, protože to byly 3 balíčky, které se navzájem blokovali v aktualizaci

Closes https://github.com/skaut/Skautske-hospodareni/pull/1719
Closes https://github.com/skaut/Skautske-hospodareni/pull/1729

---

Za zmínku stojí to, že momentálně máme kontrolované i mapování entit (tam jsem pofixoval pár problémů s `|null`)