### PR TITLE
add non breaking space to chits

### DIFF
--- a/app/model/Cashbook/ReadModel/QueryHandlers/Pdf/ExportChitsHandler.php
+++ b/app/model/Cashbook/ReadModel/QueryHandlers/Pdf/ExportChitsHandler.php
@@ -84,7 +84,7 @@ class ExportChitsHandler
 
         $officialUnit = $this->queryBus->handle(new CashbookOfficialUnitQuery($query->getCashbookId()));
         assert($officialUnit instanceof Unit);
-        $template['officialName'] = $officialUnit->getFullDisplayNameWithAddress();
+        $template['officialName'] = $officialUnit->getFullDisplayNameWithAddress(true);
         $template['cashbook']     = $cashbook;
 
         //HPD

--- a/app/model/Cashbook/ReadModel/QueryHandlers/Pdf/templates/chits.out.latte
+++ b/app/model/Cashbook/ReadModel/QueryHandlers/Pdf/templates/chits.out.latte
@@ -9,7 +9,7 @@ table {
 </style>
 <table border="1" class="paragonTable">
     <tr>
-        <td rowspan="2">{$officialName}</td>
+        <td rowspan="2">{$officialName|noescape}</td>
         <td colspan="2"><b>Výdajový pokladní doklad</b></td>
     </tr>
     <tr>

--- a/app/model/Unit/Services/Unit.php
+++ b/app/model/Unit/Services/Unit.php
@@ -84,18 +84,18 @@ class Unit
         return $this->displayName;
     }
 
-    public function getFullDisplayName(): string
+    public function getFullDisplayName(bool $nonBreakingSpace = false): string
     {
         if ($this->isOfficial()) {
-            return sprintf('Junák - český skaut, %s, z. s.', $this->getDisplayName());
+            return sprintf('Junák - český skaut, %s, z.%ss.', $this->getDisplayName(), $nonBreakingSpace ? '&nbsp;' : ' ');
         }
 
         return '';
     }
 
-    public function getFullDisplayNameWithAddress(): string
+    public function getFullDisplayNameWithAddress(bool $nonBreakingSpace = false): string
     {
-        return $this->getFullDisplayName() . ', ' . $this->getAddress() . ', IČO: ' . $this->ic;
+        return $this->getFullDisplayName($nonBreakingSpace) . ', ' . $this->getAddress() . ', IČO:' . ($nonBreakingSpace ? '&nbsp;' : ' ') . $this->ic;
     }
 
     public function getAddress(): string


### PR DESCRIPTION
Přidává nedělitelnou mezeru, pro správné zalomení v hlavičce dokladu

**Původně**
<img width="396" alt="Screenshot 2022-12-11 at 15 30 40" src="https://user-images.githubusercontent.com/1140123/206909616-a1510c78-48e4-4c16-a416-1c1ddda00f44.png">

**Nově**
<img width="399" alt="Screenshot 2022-12-11 at 15 30 14" src="https://user-images.githubusercontent.com/1140123/206909592-2b04e43b-2e01-4acc-8612-986b0c7f8383.png">
