### PR TITLE
Typo in a user-facing text.

### DIFF
--- a/app/AccountancyModule/PaymentModule/templates/Payment/massAdd.latte
+++ b/app/AccountancyModule/PaymentModule/templates/Payment/massAdd.latte
@@ -36,7 +36,7 @@
 {if $showForm}
     {control massAddForm}
 {else}
-    <span class="alert alert-warning">Nejsou dostupné žádné osoby, které by neměli založenou platbu</span>
+    <span class="alert alert-warning">Nejsou dostupné žádné osoby, které by neměly založenou platbu.</span>
 {/if}
 
 


### PR DESCRIPTION
Probably copy&pasted from the default.latte
'osoby neměly'