### PR TITLE
Odebrání @fmasa z výchozích reviewerů pro Dependabota

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,6 @@ updates:
     interval: monthly
     time: "01:00"
   open-pull-requests-limit: 20
-  reviewers:
-  - fmasa
   ignore:
   - dependency-name: sass-loader
     versions:


### PR DESCRIPTION
Vzhledem k tomu, že už asi rok prakticky nereviewuji žádné PR, tak mi nedává smysl být jako výchozí reviewer pro PR otevřené dependabotem. Jediné, co to realně znamená, že každy týden musím promazat asi 10 mailů. :grinning: 