### PR TITLE
Fixed incorrect inconsistency tooltip in Camp budget

### DIFF
--- a/app/AccountancyModule/CampModule/templates/Budget/default.latte
+++ b/app/AccountancyModule/CampModule/templates/Budget/default.latte
@@ -30,7 +30,7 @@
             {do $balance += (float)$categorySummary->total->getAmount()/100}
             <td>{$categorySummary->name}</td>
             <td n:class="text-right,text-nowrap, array_key_exists($categorySummary->id, $toRepair) ? bg-danger-lighter"
-                n:attr="[title => array_key_exists($categorySummary->id, $toRepair) ? 'Součet paragonů je ' . $toRepair[$categorySummary->id]]">
+                n:attr="[title => array_key_exists($categorySummary->id, $toRepair) ? 'Částka ve SkautISu je ' . $toRepair[$categorySummary->id]]">
                 {$categorySummary->total|price}
             </td>
         </tr>


### PR DESCRIPTION
Ten tooltip byl naopak, to, co se v něm zobrazuje je částka v ISu, součet paragonů je v tabulce

closes #2312 