### PR TITLE
Zobrazování celých názvů rolí

### DIFF
--- a/app/AccountancyModule/Components/LoginPanel.php
+++ b/app/AccountancyModule/Components/LoginPanel.php
@@ -40,7 +40,7 @@ final class LoginPanel extends BaseControl
             $roles = [];
 
             foreach ($this->userService->getAllSkautisRoles() as $role) {
-                $roles[$role->ID] = isset($role->RegistrationNumber) ? $role->RegistrationNumber . ' - ' . $role->Role : $role->Role;
+                $roles[$role->ID] = $role->DisplayName;
             }
 
             $this->template->setParameters([

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -27,7 +27,7 @@ class AcceptanceTester extends Actor
 
     private const PASSWORD = 'chtelbysprachy1';
 
-    public const UNIT_LEADER_ROLE = '621.66 - Středisko: vedoucí/admin';
+    public const UNIT_LEADER_ROLE = 'Středisko: vedoucí/admin - 621.66';
     public const UNIT_ID = 27266;
 
     /**


### PR DESCRIPTION
Před:

![image](https://github.com/skaut/Skautske-hospodareni/assets/3134692/a450cdea-9da1-4932-92eb-baa77f6f3962)

Po:

![image](https://github.com/skaut/Skautske-hospodareni/assets/3134692/673958a6-2199-4dcf-b5cb-8b2ea8e038d1)

Closes #2363. Ty role jsou podle mě zbytečně složitý, ale SkautIS to prý měnit nebude. A parsovat si to z toho sám fakt nechci...

Mimochodem pro tábory je to podle mě taky upgrade...