### PR TITLE
MySQL v dockeru na portu 33060

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -10,7 +10,7 @@ services:
 #            - nfsmount:/var/www/html
     mysql:
         ports:
-            - 3306:3306
+            - 33060:3306
 
     adminer:
         container_name: hskauting.adminer


### PR DESCRIPTION
Mám lokální MySQL server a při spuštění dockeru se to s ním tříská - tenhle PR pouští MySQL na poru 33060, takže to pak nemá konflikt s ne-dockerovým MySQL.
