### PR TITLE
Pokladní knihy vzdělávaček a jejich kategorie specifické pro rok

### DIFF
--- a/app/AccountancyModule/EducationModule/EducationListDataSource.php
+++ b/app/AccountancyModule/EducationModule/EducationListDataSource.php
@@ -54,7 +54,7 @@ final class EducationListDataSource extends DataSource
 
     private function chitNumberPrefix(Education $camp): string|null
     {
-        $cashbookId = $this->queryBus->handle(new EducationCashbookIdQuery($camp->getId(), $camp->endDate->year));
+        $cashbookId = $this->queryBus->handle(new EducationCashbookIdQuery($camp->getId(), $camp->startDate->year));
 
         assert($cashbookId instanceof CashbookId);
 

--- a/app/AccountancyModule/EducationModule/EducationListDataSource.php
+++ b/app/AccountancyModule/EducationModule/EducationListDataSource.php
@@ -54,7 +54,7 @@ final class EducationListDataSource extends DataSource
 
     private function chitNumberPrefix(Education $camp): string|null
     {
-        $cashbookId = $this->queryBus->handle(new EducationCashbookIdQuery($camp->getId()));
+        $cashbookId = $this->queryBus->handle(new EducationCashbookIdQuery($camp->getId(), $camp->endDate->year));
 
         assert($cashbookId instanceof CashbookId);
 

--- a/app/AccountancyModule/EducationModule/presenters/BudgetPresenter.php
+++ b/app/AccountancyModule/EducationModule/presenters/BudgetPresenter.php
@@ -44,12 +44,12 @@ class BudgetPresenter extends BasePresenter
 
         $educationId = new SkautisEducationId($aid);
 
-        $inconsistentTotals = $this->queryBus->handle(new InconsistentEducationCategoryTotalsQuery($educationId, $this->event->endDate->year));
+        $inconsistentTotals = $this->queryBus->handle(new InconsistentEducationCategoryTotalsQuery($educationId, $this->event->startDate->year));
         $this->template->setParameters([
             'isConsistent'             => count($inconsistentTotals) === 0,
             'toRepair'                 => $inconsistentTotals,
             'budgetEntries'            => $this->queryBus->handle(new EducationBudgetQuery($educationId, $this->event->grantId)),
-            'categoriesSummary'        => $this->queryBus->handle(new CategoriesSummaryQuery($this->getCashbookId($aid, $this->event->endDate->year))),
+            'categoriesSummary'        => $this->queryBus->handle(new CategoriesSummaryQuery($this->getCashbookId($aid, $this->event->startDate->year))),
             'isUpdateStatementAllowed' => $this->authorizator->isAllowed(Grant::UPDATE_REAL_BUDGET_SPENDING, $this->event->grantId->toInt()),
         ]);
         if (! $this->isAjax()) {
@@ -66,7 +66,7 @@ class BudgetPresenter extends BasePresenter
     {
         $this->editableOnly();
 
-        $this->commandBus->handle(new UpdateEducationCategoryTotals($this->getCashbookId($aid, $this->event->endDate->year)));
+        $this->commandBus->handle(new UpdateEducationCategoryTotals($this->getCashbookId($aid, $this->event->startDate->year)));
         $this->flashMessage('Kategorie byly přepočítány.');
 
         if ($this->isAjax()) {

--- a/app/AccountancyModule/EducationModule/presenters/BudgetPresenter.php
+++ b/app/AccountancyModule/EducationModule/presenters/BudgetPresenter.php
@@ -44,12 +44,12 @@ class BudgetPresenter extends BasePresenter
 
         $educationId = new SkautisEducationId($aid);
 
-        $inconsistentTotals = $this->queryBus->handle(new InconsistentEducationCategoryTotalsQuery($educationId));
+        $inconsistentTotals = $this->queryBus->handle(new InconsistentEducationCategoryTotalsQuery($educationId, $this->event->endDate->year));
         $this->template->setParameters([
             'isConsistent'             => count($inconsistentTotals) === 0,
             'toRepair'                 => $inconsistentTotals,
             'budgetEntries'            => $this->queryBus->handle(new EducationBudgetQuery($educationId, $this->event->grantId)),
-            'categoriesSummary'        => $this->queryBus->handle(new CategoriesSummaryQuery($this->getCashbookId($aid))),
+            'categoriesSummary'        => $this->queryBus->handle(new CategoriesSummaryQuery($this->getCashbookId($aid, $this->event->endDate->year))),
             'isUpdateStatementAllowed' => $this->authorizator->isAllowed(Grant::UPDATE_REAL_BUDGET_SPENDING, $this->event->grantId->toInt()),
         ]);
         if (! $this->isAjax()) {
@@ -66,7 +66,7 @@ class BudgetPresenter extends BasePresenter
     {
         $this->editableOnly();
 
-        $this->commandBus->handle(new UpdateEducationCategoryTotals($this->getCashbookId($aid)));
+        $this->commandBus->handle(new UpdateEducationCategoryTotals($this->getCashbookId($aid, $this->event->endDate->year)));
         $this->flashMessage('Kategorie byly přepočítány.');
 
         if ($this->isAjax()) {
@@ -76,8 +76,8 @@ class BudgetPresenter extends BasePresenter
         }
     }
 
-    private function getCashbookId(int $educationId): CashbookId
+    private function getCashbookId(int $educationId, int $year): CashbookId
     {
-        return $this->queryBus->handle(new EducationCashbookIdQuery(new SkautisEducationId($educationId)));
+        return $this->queryBus->handle(new EducationCashbookIdQuery(new SkautisEducationId($educationId), $year));
     }
 }

--- a/app/AccountancyModule/EducationModule/presenters/CashbookPresenter.php
+++ b/app/AccountancyModule/EducationModule/presenters/CashbookPresenter.php
@@ -114,7 +114,7 @@ class CashbookPresenter extends BasePresenter
         $body    = new ChitBody(null, $this->event->getStartDate(), null);
 
         $categoryId    = $this->queryBus->handle(
-            new EducationParticipantCategoryIdQuery(new SkautisEducationId($this->aid)),
+            new EducationParticipantCategoryIdQuery(new SkautisEducationId($this->aid), $this->event->endDate->year),
         );
         $categoriesDto = $this->queryBus->handle(new CategoryListQuery($this->getCashbookId()));
 

--- a/app/AccountancyModule/EducationModule/presenters/CashbookPresenter.php
+++ b/app/AccountancyModule/EducationModule/presenters/CashbookPresenter.php
@@ -114,7 +114,7 @@ class CashbookPresenter extends BasePresenter
         $body    = new ChitBody(null, $this->event->getStartDate(), null);
 
         $categoryId    = $this->queryBus->handle(
-            new EducationParticipantCategoryIdQuery(new SkautisEducationId($this->aid), $this->event->endDate->year),
+            new EducationParticipantCategoryIdQuery(new SkautisEducationId($this->aid), $this->event->startDate->year),
         );
         $categoriesDto = $this->queryBus->handle(new CategoryListQuery($this->getCashbookId()));
 
@@ -128,7 +128,7 @@ class CashbookPresenter extends BasePresenter
 
     private function getCashbookId(): CashbookId
     {
-        return $this->queryBus->handle(new EducationCashbookIdQuery(new SkautisEducationId($this->aid), $this->event->endDate->year));
+        return $this->queryBus->handle(new EducationCashbookIdQuery(new SkautisEducationId($this->aid), $this->event->startDate->year));
     }
 
     private function isCashbookEmpty(): bool

--- a/app/AccountancyModule/EducationModule/presenters/CashbookPresenter.php
+++ b/app/AccountancyModule/EducationModule/presenters/CashbookPresenter.php
@@ -128,7 +128,7 @@ class CashbookPresenter extends BasePresenter
 
     private function getCashbookId(): CashbookId
     {
-        return $this->queryBus->handle(new EducationCashbookIdQuery(new SkautisEducationId($this->aid)));
+        return $this->queryBus->handle(new EducationCashbookIdQuery(new SkautisEducationId($this->aid), $this->event->endDate->year));
     }
 
     private function isCashbookEmpty(): bool

--- a/app/AccountancyModule/EducationModule/presenters/EducationPresenter.php
+++ b/app/AccountancyModule/EducationModule/presenters/EducationPresenter.php
@@ -50,13 +50,13 @@ class EducationPresenter extends BasePresenter
             $this->redirect('Default:');
         }
 
-        $cashbook = $this->queryBus->handle(new CashbookQuery($this->getCashbookId($aid, $this->event->endDate->year)));
+        $cashbook = $this->queryBus->handle(new CashbookQuery($this->getCashbookId($aid, $this->event->startDate->year)));
         assert($cashbook instanceof Cashbook);
 
         $finalRealBalance = null;
         if ($this->authorizator->isAllowed(Education::ACCESS_BUDGET, $aid)) {
             try {
-                $finalRealBalance = $this->queryBus->handle(new FinalRealBalanceQuery($this->getCashbookId($aid, $this->event->endDate->year)));
+                $finalRealBalance = $this->queryBus->handle(new FinalRealBalanceQuery($this->getCashbookId($aid, $this->event->startDate->year)));
             } catch (MissingCategory) {
             }
         }
@@ -134,7 +134,7 @@ class EducationPresenter extends BasePresenter
             $this->redirect('default', ['aid' => $aid]);
         }
 
-        $template = $this->exportService->getEducationReport(new SkautisEducationId($aid), $this->event->endDate->year);
+        $template = $this->exportService->getEducationReport(new SkautisEducationId($aid), $this->event->startDate->year);
 
         $this->pdf->render($template, 'report.pdf');
         $this->terminate();

--- a/app/AccountancyModule/EducationModule/presenters/EducationPresenter.php
+++ b/app/AccountancyModule/EducationModule/presenters/EducationPresenter.php
@@ -50,13 +50,13 @@ class EducationPresenter extends BasePresenter
             $this->redirect('Default:');
         }
 
-        $cashbook = $this->queryBus->handle(new CashbookQuery($this->getCashbookId($aid)));
+        $cashbook = $this->queryBus->handle(new CashbookQuery($this->getCashbookId($aid, $this->event->endDate->year)));
         assert($cashbook instanceof Cashbook);
 
         $finalRealBalance = null;
         if ($this->authorizator->isAllowed(Education::ACCESS_BUDGET, $aid)) {
             try {
-                $finalRealBalance = $this->queryBus->handle(new FinalRealBalanceQuery($this->getCashbookId($aid)));
+                $finalRealBalance = $this->queryBus->handle(new FinalRealBalanceQuery($this->getCashbookId($aid, $this->event->endDate->year)));
             } catch (MissingCategory) {
             }
         }
@@ -134,15 +134,15 @@ class EducationPresenter extends BasePresenter
             $this->redirect('default', ['aid' => $aid]);
         }
 
-        $template = $this->exportService->getEducationReport(new SkautisEducationId($aid));
+        $template = $this->exportService->getEducationReport(new SkautisEducationId($aid), $this->event->endDate->year);
 
         $this->pdf->render($template, 'report.pdf');
         $this->terminate();
     }
 
-    private function getCashbookId(int $skautisEducationId): CashbookId
+    private function getCashbookId(int $skautisEducationId, int $year): CashbookId
     {
-        return $this->queryBus->handle(new EducationCashbookIdQuery(new SkautisEducationId($skautisEducationId)));
+        return $this->queryBus->handle(new EducationCashbookIdQuery(new SkautisEducationId($skautisEducationId), $year));
     }
 
     /**

--- a/app/model/Cashbook/Education.php
+++ b/app/model/Cashbook/Education.php
@@ -21,18 +21,30 @@ class Education extends Aggregate
      */
     private SkautisEducationId $id;
 
+    /**
+     * @ORM\Id()
+     * @ORM\Column(type="int")
+     */
+    private int $year;
+
     /** @ORM\Column(type="cashbook_id") */
     private CashbookId $cashbookId;
 
-    public function __construct(SkautisEducationId $id, CashbookId $cashbookId)
+    public function __construct(SkautisEducationId $id, int $year, CashbookId $cashbookId)
     {
         $this->id         = $id;
+        $this->year       = $year;
         $this->cashbookId = $cashbookId;
     }
 
     public function getSkautisId(): SkautisEducationId
     {
         return $this->id;
+    }
+
+    public function getYear(): int
+    {
+        return $this->year;
     }
 
     public function getCashbookId(): CashbookId

--- a/app/model/Cashbook/Education.php
+++ b/app/model/Cashbook/Education.php
@@ -22,6 +22,8 @@ class Education extends Aggregate
     private SkautisEducationId $id;
 
     /**
+     * For education events spanning multiple years, a separate cashbook is needed for each year.
+     *
      * @ORM\Id()
      * @ORM\Column(type="integer")
      */

--- a/app/model/Cashbook/Education.php
+++ b/app/model/Cashbook/Education.php
@@ -23,7 +23,7 @@ class Education extends Aggregate
 
     /**
      * @ORM\Id()
-     * @ORM\Column(type="int")
+     * @ORM\Column(type="integer")
      */
     private int $year;
 

--- a/app/model/Cashbook/ReadModel/Queries/EducationCashbookIdQuery.php
+++ b/app/model/Cashbook/ReadModel/Queries/EducationCashbookIdQuery.php
@@ -11,7 +11,7 @@ final class EducationCashbookIdQuery
 {
     private SkautisEducationId $educationId;
 
-    public function __construct(SkautisEducationId $eventId)
+    public function __construct(SkautisEducationId $eventId, private int $year)
     {
         $this->educationId = $eventId;
     }
@@ -19,5 +19,10 @@ final class EducationCashbookIdQuery
     public function getEducationId(): SkautisEducationId
     {
         return $this->educationId;
+    }
+
+    public function getYear(): int
+    {
+        return $this->year;
     }
 }

--- a/app/model/Cashbook/ReadModel/Queries/EducationParticipantCategoryIdQuery.php
+++ b/app/model/Cashbook/ReadModel/Queries/EducationParticipantCategoryIdQuery.php
@@ -10,12 +10,17 @@ use Model\Event\SkautisEducationId;
 /** @see EducationParticipantCategoryIdQueryHandler */
 final class EducationParticipantCategoryIdQuery
 {
-    public function __construct(private SkautisEducationId $educationId)
+    public function __construct(private SkautisEducationId $educationId, private int $year)
     {
     }
 
     public function getEducationId(): SkautisEducationId
     {
         return $this->educationId;
+    }
+
+    public function getYear(): int
+    {
+        return $this->year;
     }
 }

--- a/app/model/Cashbook/ReadModel/Queries/InconsistentEducationCategoryTotalsQuery.php
+++ b/app/model/Cashbook/ReadModel/Queries/InconsistentEducationCategoryTotalsQuery.php
@@ -14,12 +14,17 @@ use Model\Event\SkautisEducationId;
  */
 final class InconsistentEducationCategoryTotalsQuery
 {
-    public function __construct(private SkautisEducationId $educationId)
+    public function __construct(private SkautisEducationId $educationId, private int $year)
     {
     }
 
     public function getEducationId(): SkautisEducationId
     {
         return $this->educationId;
+    }
+
+    public function getYear(): int
+    {
+        return $this->year;
     }
 }

--- a/app/model/Cashbook/ReadModel/Queries/SkautisEducationYearQuery.php
+++ b/app/model/Cashbook/ReadModel/Queries/SkautisEducationYearQuery.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Model\Cashbook\ReadModel\Queries;
+
+use Model\Cashbook\Cashbook\CashbookId;
+use Model\Cashbook\ReadModel\QueryHandlers\SkautisEducationYearQueryHandler;
+
+/** @see SkautisEducationYearQueryHandler */
+final class SkautisEducationYearQuery
+{
+    public function __construct(private CashbookId $cashbookId)
+    {
+    }
+
+    public function getCashbookId(): CashbookId
+    {
+        return $this->cashbookId;
+    }
+}

--- a/app/model/Cashbook/ReadModel/QueryHandlers/EducationCashbookIdQueryHandler.php
+++ b/app/model/Cashbook/ReadModel/QueryHandlers/EducationCashbookIdQueryHandler.php
@@ -16,6 +16,6 @@ final class EducationCashbookIdQueryHandler
 
     public function __invoke(EducationCashbookIdQuery $query): CashbookId
     {
-        return $this->eventRepository->findBySkautisId($query->getEducationId())->getCashbookId();
+        return $this->eventRepository->findBySkautisIdAndYear($query->getEducationId(), $query->getYear())->getCashbookId();
     }
 }

--- a/app/model/Cashbook/ReadModel/QueryHandlers/EducationParticipantCategoryIdQueryHandler.php
+++ b/app/model/Cashbook/ReadModel/QueryHandlers/EducationParticipantCategoryIdQueryHandler.php
@@ -16,7 +16,7 @@ class EducationParticipantCategoryIdQueryHandler
 
     public function __invoke(EducationParticipantCategoryIdQuery $query): int
     {
-        foreach ($this->categories->findForEducation($query->getEducationId()->toInt()) as $category) {
+        foreach ($this->categories->findForEducation($query->getEducationId()->toInt(), $query->getYear()) as $category) {
             if ($category->getName() === 'Účastnické poplatky') {
                 return $category->getId();
             }

--- a/app/model/Cashbook/ReadModel/QueryHandlers/InconsistentEducationCategoryTotalsQueryHandler.php
+++ b/app/model/Cashbook/ReadModel/QueryHandlers/InconsistentEducationCategoryTotalsQueryHandler.php
@@ -23,7 +23,7 @@ class InconsistentEducationCategoryTotalsQueryHandler
     /** @return float[] */
     public function __invoke(InconsistentEducationCategoryTotalsQuery $query): array
     {
-        $cashbookId = $this->queryBus->handle(new EducationCashbookIdQuery($query->getEducationId()));
+        $cashbookId = $this->queryBus->handle(new EducationCashbookIdQuery($query->getEducationId(), $query->getYear()));
         $categories = $this->queryBus->handle(new CategoriesSummaryQuery($cashbookId));
 
         $skautisTotals = [];

--- a/app/model/Cashbook/ReadModel/QueryHandlers/InconsistentEducationCategoryTotalsQueryHandler.php
+++ b/app/model/Cashbook/ReadModel/QueryHandlers/InconsistentEducationCategoryTotalsQueryHandler.php
@@ -28,7 +28,7 @@ class InconsistentEducationCategoryTotalsQueryHandler
 
         $skautisTotals = [];
 
-        foreach ($this->educationCategories->findForEducation($query->getEducationId()->toInt()) as $educationCategory) {
+        foreach ($this->educationCategories->findForEducation($query->getEducationId()->toInt(), $query->getYear()) as $educationCategory) {
             $id       = $educationCategory->getId();
             $total    = $educationCategory->getTotal();
             $category = $categories[$id];

--- a/app/model/Cashbook/ReadModel/QueryHandlers/SkautisEducationYearQueryHandler.php
+++ b/app/model/Cashbook/ReadModel/QueryHandlers/SkautisEducationYearQueryHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Model\Cashbook\ReadModel\QueryHandlers;
+
+use Model\Cashbook\CashbookNotFound;
+use Model\Cashbook\Exception\UnitNotFound;
+use Model\Cashbook\ObjectType;
+use Model\Cashbook\ReadModel\Queries\SkautisEducationYearQuery;
+use Model\Cashbook\Repositories\ICashbookRepository;
+use Model\Cashbook\Repositories\IEducationRepository;
+use Model\Common\ShouldNotHappen;
+
+class SkautisEducationYearQueryHandler
+{
+    public function __construct(
+        private ICashbookRepository $cashbooks,
+        private IEducationRepository $educationRepository,
+    ) {
+    }
+
+    /**
+     * @throws CashbookNotFound
+     * @throws UnitNotFound
+     */
+    public function __invoke(SkautisEducationYearQuery $query): int
+    {
+        $cashbook   = $this->cashbooks->find($query->getCashbookId());
+        $objectType = $cashbook->getType()->getSkautisObjectType();
+
+        if (! $objectType->equalsValue(ObjectType::EDUCATION)) {
+            throw new ShouldNotHappen();
+        }
+
+        return $this->educationRepository->findByCashbookId($query->getCashbookId())->getYear();
+    }
+}

--- a/app/model/Cashbook/Repositories/CategoryRepository.php
+++ b/app/model/Cashbook/Repositories/CategoryRepository.php
@@ -8,6 +8,7 @@ use Model\Cashbook\Cashbook\CashbookId;
 use Model\Cashbook\Cashbook\CashbookType;
 use Model\Cashbook\CategoryNotFound;
 use Model\Cashbook\ICategory;
+use Model\Cashbook\ReadModel\Queries\SkautisEducationYearQuery;
 use Model\Cashbook\ReadModel\Queries\SkautisIdQuery;
 use Model\Common\Services\QueryBus;
 
@@ -39,7 +40,8 @@ class CategoryRepository
 
         if ($skautisType->equalsValue(CashbookType::EDUCATION)) {
             $educationId         = $this->queryBus->handle(new SkautisIdQuery($cashbookId));
-            $educationCategories = $this->educationCategories->findForEducation($educationId);
+            $educationYear       = $this->queryBus->handle(new SkautisEducationYearQuery($cashbookId));
+            $educationCategories = $this->educationCategories->findForEducation($educationId, $educationYear);
 
             return array_merge($categories, $educationCategories);
         }

--- a/app/model/Cashbook/Repositories/IEducationCategoryRepository.php
+++ b/app/model/Cashbook/Repositories/IEducationCategoryRepository.php
@@ -9,5 +9,5 @@ use Model\Cashbook\EducationCategory;
 interface IEducationCategoryRepository
 {
     /** @return EducationCategory[] */
-    public function findForEducation(int $educationId): array;
+    public function findForEducation(int $educationId, int $year): array;
 }

--- a/app/model/Cashbook/Repositories/IEducationRepository.php
+++ b/app/model/Cashbook/Repositories/IEducationRepository.php
@@ -12,7 +12,7 @@ use Model\Event\SkautisEducationId;
 interface IEducationRepository
 {
     /** @throws CashbookNotFound */
-    public function findBySkautisId(SkautisEducationId $id): Education;
+    public function findBySkautisIdAndYear(SkautisEducationId $id, int $year): Education;
 
     /** @throws CashbookNotFound */
     public function findByCashbookId(CashbookId $cashbookId): Education;

--- a/app/model/Export/ExportService.php
+++ b/app/model/Export/ExportService.php
@@ -270,9 +270,9 @@ class ExportService
         ]);
     }
 
-    public function getEducationReport(SkautisEducationId $educationId): string
+    public function getEducationReport(SkautisEducationId $educationId, int $year): string
     {
-        $cashbookId = $this->queryBus->handle(new EducationCashbookIdQuery($educationId));
+        $cashbookId = $this->queryBus->handle(new EducationCashbookIdQuery($educationId, $year));
         $categories = $this->queryBus->handle(new CategoriesSummaryQuery($cashbookId));
 
         $total = [

--- a/app/model/Infrastructure/Repositories/Cashbook/EducationRepository.php
+++ b/app/model/Infrastructure/Repositories/Cashbook/EducationRepository.php
@@ -24,7 +24,7 @@ final class EducationRepository extends AggregateRepository implements IEducatio
         parent::__construct($entityManager, $eventBus);
     }
 
-    public function findBySkautisId(SkautisEducationId $id): Education
+    public function findBySkautisIdAndYear(SkautisEducationId $id, int $year): Education
     {
         $builder = $this->getEntityManager()->createQueryBuilder();
 
@@ -36,7 +36,7 @@ final class EducationRepository extends AggregateRepository implements IEducatio
                 ->getQuery()
                 ->getSingleResult();
         } catch (NoResultException) {
-            $cashbook = new Education($id, CashbookId::generate());
+            $cashbook = new Education($id, $year, CashbookId::generate());
             $this->save($cashbook);
 
             $this->commandBus->handle(new CreateCashbook($cashbook->getCashbookId(), CashbookType::get(CashbookType::EDUCATION)));

--- a/app/model/Skautis/Cashbook/EducationCategoryUpdater.php
+++ b/app/model/Skautis/Cashbook/EducationCategoryUpdater.php
@@ -36,7 +36,8 @@ final class EducationCategoryUpdater implements IEducationCategoryUpdater
     public function updateCategories(CashbookId $cashbookId, array $cashbookTotals): void
     {
         $educationSkautisId = $this->educationRepository->findByCashbookId($cashbookId)->getSkautisId();
-        $skautisTotals      = $this->getSkautisTotals($educationSkautisId);
+        $educationYear      = $this->educationRepository->findByCashbookId($cashbookId)->getYear();
+        $skautisTotals      = $this->getSkautisTotals($educationSkautisId, $educationYear);
 
         // Update categories that are not in cashbook, has total > 0 in Skautis
         $categoriesOnlyInSkautis = array_diff(array_keys($skautisTotals), array_keys($cashbookTotals));
@@ -74,9 +75,9 @@ final class EducationCategoryUpdater implements IEducationCategoryUpdater
     }
 
     /** @return float[] */
-    private function getSkautisTotals(SkautisEducationId $educationSkautisId): array
+    private function getSkautisTotals(SkautisEducationId $educationSkautisId, int $year): array
     {
-        $categories = $this->educationCategories->findForEducation($educationSkautisId->toInt());
+        $categories = $this->educationCategories->findForEducation($educationSkautisId->toInt(), $year);
         $totals     = [];
 
         foreach ($categories as $category) {

--- a/app/model/Skautis/Cashbook/Repositories/EducationCategoryRepository.php
+++ b/app/model/Skautis/Cashbook/Repositories/EducationCategoryRepository.php
@@ -22,11 +22,12 @@ final class EducationCategoryRepository implements IEducationCategoryRepository
 
     /** @return EducationCategory[] */
     // phpcs:disable Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-    public function findForEducation(int $educationId): array
+    public function findForEducation(int $educationId, int $year): array
     {
         $skautisCategories = $this->grantsWebService->StatementAll([
             'ID_EventEducation' => $educationId,
             'IsBudget' => false,
+            'Year' => $year,
         ]);
 
         if (is_object($skautisCategories)) {

--- a/migrations/2023/Version20231025231859.php
+++ b/migrations/2023/Version20231025231859.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20231025231859 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Přidání roků pro pokladní knihy vzdělávacích akcí';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE `ac_education_cashbooks` ADD COLUMN `year` INT NOT NULL AFTER `id`;');
+        $this->addSql('ALTER TABLE `ac_education_cashbooks` DROP PRIMARY KEY, ADD PRIMARY KEY(`id`, `year`);');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE `ac_education_cashbooks` DROP PRIMARY KEY, ADD PRIMARY KEY(`id`);');
+        $this->addSql('ALTER TABLE `ac_education_cashbooks` DROP COLUMN `year`;');
+    }
+}


### PR DESCRIPTION
- Opravuje SkautISovou chybu při načítání kategorií vzdělávačky
- Pokladní knihy vzdělávaček se nově ukládají pro kombinaci vzdělávačka + rok
- Za rok vzdělávačky se bere vždy rok jejího posledního dne
- Trochu pokládá základy pro #2331 - v rovině databáze a ukládání pokladních knih, co se UI týče, tak vůbec.

fixes H-SKAUTING-CZ-1GT
