### PR TITLE
Refactor ActivateCashbookDialog to use Dialog base class

### DIFF
--- a/app/AccountancyModule/UnitAccountModule/Components/ActivateCashbookDialog.php
+++ b/app/AccountancyModule/UnitAccountModule/Components/ActivateCashbookDialog.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\AccountancyModule\UnitAccountModule\Components;
 
-use App\AccountancyModule\Components\BaseControl;
+use App\AccountancyModule\Components\Dialog;
 use App\Forms\BaseForm;
 use Model\Cashbook\Commands\Unit\ActivateCashbook;
 use Model\Cashbook\ReadModel\Queries\ActiveUnitCashbookQuery;
@@ -18,7 +18,7 @@ use Nette\Utils\ArrayHash;
 use function assert;
 use function sprintf;
 
-final class ActivateCashbookDialog extends BaseControl
+final class ActivateCashbookDialog extends Dialog
 {
      /** @var bool @persistent */
     public bool $opened = false;
@@ -30,13 +30,12 @@ final class ActivateCashbookDialog extends BaseControl
     {
     }
 
-    public function render(): void
+    public function beforeRender(): void
     {
         $this->template->setFile(__DIR__ . '/templates/ActivateCashbookDialog.latte');
         $this->template->setParameters([
             'renderModal' => $this->opened,
         ]);
-        $this->template->render();
     }
 
     public function open(): void

--- a/app/AccountancyModule/UnitAccountModule/Components/templates/ActivateCashbookDialog.latte
+++ b/app/AccountancyModule/UnitAccountModule/Components/templates/ActivateCashbookDialog.latte
@@ -1,4 +1,27 @@
-<div n:snippet n:inner-if="$renderModal" class="modal {if $renderModal}rendered{/if}" tabindex="-1">
+{layout $layout}
+
+{define control $input, $extraClasses}
+    <input n:name="$input" n:class="$input->hasErrors() ? 'is-invalid', form-control, $extraClasses ?? ''">
+{/define}
+
+{define errors $input}
+    <div class="invalid-feedback d-block" n:foreach="$input->getErrors() as $error">{$error}</div>
+{/define}
+
+
+{block dialog-title}Vybrat výchozí pokladní knihu{/block}
+
+{block dialog-body}
+    <p>Tato kniha bude zobrazena po příchodu na stránku <i>Jednotka &#8658; Evidence plateb</i></p>
+    {control form}
+
+
+{/block}
+
+
+
+
+{*<div n:snippet n:inner-if="$renderModal" class="modal {if $renderModal}rendered{/if}" tabindex="-1">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
@@ -14,4 +37,4 @@
             </div>
         </div>
     </div>
-</div>
+</div>*}


### PR DESCRIPTION
Updated ActivateCashbookDialog to extend Dialog instead of BaseControl for better consistency with other components. Refactored the rendering logic to use a beforeRender method and updated the Latte template to align with the new structure and rendering approach. This ensures cleaner and more modular code.