### PR TITLE
Uprav nasazování do beta prostředí podle podmínky větve

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -225,7 +225,7 @@ jobs:
 
     deploy-beta:
         name: "Deploy to beta-h.skauting.cz"
-        environment: beta
+        if: github.ref == 'refs/heads/beta'
         needs: [checks-passed]
         runs-on: ubuntu-22.04
         container:


### PR DESCRIPTION
Přidána podmínka kontroly větve `beta` před nasazením na beta prostředí. Zajišťuje, že proces proběhne pouze při změnách v odpovídající větvi.