### PR TITLE
Ošetři nulovou hodnotu u VariableSymbol

### DIFF
--- a/app/model/Skautis/ParticipantRepository.php
+++ b/app/model/Skautis/ParticipantRepository.php
@@ -91,7 +91,7 @@ final class ParticipantRepository implements IParticipantRepository
                 $invitation                         = $invitations[$person->ID_EventCampInvitation];
                 $paymentDetails[$person->ID_Person] = new PaymentDetails(
                     $person->ID_Person,
-                    $person->VariableSymbol,
+                    $person->VariableSymbol ?? '',
                     (float) $invitation->Price,
                     $invitation->PaymentNote,
                     $invitation->SpecificSymbol,


### PR DESCRIPTION
Přiřazení prázdného řetězce zajistí, že null hodnota u VariableSymbol nezpůsobí chybu.