### PR TITLE
Restore server-side authorization for education report export

### DIFF
--- a/app/AccountancyModule/EducationModule/presenters/EducationPresenter.php
+++ b/app/AccountancyModule/EducationModule/presenters/EducationPresenter.php
@@ -128,6 +128,15 @@ class EducationPresenter extends BasePresenter
 
     public function renderReport(int $aid): void
     {
+        if (
+            $this->event->startDate === null
+            || ! $this->authorizator->isAllowed(Education::ACCESS_DETAIL, $aid)
+            || ! $this->authorizator->isAllowed(Education::ACCESS_BUDGET, $aid)
+        ) {
+            $this->flashMessage('Nemáte právo přistupovat ke kurzu', 'warning');
+            $this->redirect('default', ['aid' => $aid]);
+        }
+
         $template = $this->exportService->getEducationReport(new SkautisEducationId($aid), $this->event->startDate->year);
 
         $this->pdf->render($template, 'report.pdf');


### PR DESCRIPTION
### Motivation
- The education report export endpoint lacked server-side authorization and could be accessed directly via URL, exposing budget and participant data; the guard was reintroduced to prevent this server-side access control gap.

### Description
- Add an explicit guard in `EducationPresenter::renderReport()` that checks `startDate` and requires `Education::ACCESS_DETAIL` and `Education::ACCESS_BUDGET`, and otherwise flashes a warning and redirects to `default`.

### Testing
- Ran `php -l app/AccountancyModule/EducationModule/presenters/EducationPresenter.php` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b5d83a59088325863e6ba5c8995270)