### PR TITLE
fix: auto-detect Docker socket path for Traefik

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 SHELL := /bin/bash
 
+# Docker daemon socket mounted into Traefik for service discovery. Auto-detected
+# from the active Docker context (works for both rootful and rootless Docker);
+# falls back to the standard rootful socket. Override by exporting DOCKER_SOCKET.
+export DOCKER_SOCKET ?= $(shell docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null | sed -n 's|^unix://||p')
+
 COMPOSE         = docker compose -f docker/docker-compose.yml
 RUN_PHP_DEV     = $(COMPOSE) run --rm -T --user root php
 RUN_PHP_TEST    = $(COMPOSE) run --rm -T --user root php-test

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -47,7 +47,7 @@ services:
         ports:
             - "80:80"
         volumes:
-            - /run/user/1000/docker.sock:/var/run/docker.sock:ro
+            - ${DOCKER_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock:ro
             - ./containers/traefik/traefik.yml:/traefik.yml:ro
         labels:
             traefik.enable: true


### PR DESCRIPTION
Opravuje #3147.

## Problém

Traefik měl v `docker/docker-compose.yml` natvrdo připojený rootless Docker socket (`/run/user/1000/docker.sock`). Na rootful Dockeru zdroj bind mountu není socket, takže Docker uvnitř kontejneru vytvořil na `/var/run/docker.sock` prázdný adresář. Traefik se nemohl připojit k Docker API, nenačetl žádné routery a na všechny hosty — včetně `moje-hospodareni.cz` — vracel vlastní `404 page not found`. Cesta navíc předpokládala UID 1000.

## Řešení

- `Makefile` zjistí socket z aktivního Docker contextu a exportuje `DOCKER_SOCKET`:
  ```make
  export DOCKER_SOCKET ?= $(shell docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null | sed -n 's|^unix://||p')
  ```
- `docker/docker-compose.yml` hodnotu použije s fallbackem:
  ```yaml
  - ${DOCKER_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock:ro
  ```

Funguje pro rootful i rootless Docker bez natvrdo zadaného UID. Při přímém `docker compose` (mimo make) nebo u vzdáleného TCP démona se použije fallback `/var/run/docker.sock`. Lze přepsat přes `DOCKER_SOCKET=… make up`.

## Ověření

`make`-resolved `DOCKER_SOCKET=/var/run/docker.sock`, Traefik znovu vytvořen přes Makefile se správným bind mountem, 0 chyb připojení k socketu, `http://moje-hospodareni.cz/` vrací HTTP 200.