### PR TITLE
feat: track recently visited payment groups and adjust dashboard display

### DIFF
--- a/app/Model/Payment/ReadModel/Queries/RecentlyVisitedGroupsQuery.php
+++ b/app/Model/Payment/ReadModel/Queries/RecentlyVisitedGroupsQuery.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\Payment\ReadModel\Queries;
+
+use App\Model\Payment\ReadModel\QueryHandlers\RecentlyVisitedGroupsQueryHandler;
+
+/** @see RecentlyVisitedGroupsQueryHandler */
+final class RecentlyVisitedGroupsQuery
+{
+    /** @param int[] $unitIds */
+    public function __construct(
+        private int $userId,
+        private array $unitIds,
+        private int $limit,
+    ) {
+    }
+
+    public function getUserId(): int
+    {
+        return $this->userId;
+    }
+
+    /** @return int[] */
+    public function getUnitIds(): array
+    {
+        return $this->unitIds;
+    }
+
+    public function getLimit(): int
+    {
+        return $this->limit;
+    }
+}

--- a/app/Model/Payment/ReadModel/QueryHandlers/RecentlyVisitedGroupsQueryHandler.php
+++ b/app/Model/Payment/ReadModel/QueryHandlers/RecentlyVisitedGroupsQueryHandler.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\Payment\ReadModel\QueryHandlers;
+
+use App\Model\DTO\Payment\Group;
+use App\Model\DTO\Payment\GroupFactory;
+use App\Model\Payment\ReadModel\Queries\RecentlyVisitedGroupsQuery;
+use App\Model\User\Repository\PaymentGroupVisitRepository;
+
+use function array_map;
+
+final class RecentlyVisitedGroupsQueryHandler
+{
+    public function __construct(private PaymentGroupVisitRepository $visits)
+    {
+    }
+
+    /** @return Group[] */
+    public function __invoke(RecentlyVisitedGroupsQuery $query): array
+    {
+        $groups = $this->visits->findRecentlyVisitedGroups(
+            $query->getUserId(),
+            $query->getUnitIds(),
+            $query->getLimit(),
+        );
+
+        return array_map([GroupFactory::class, 'create'], $groups);
+    }
+}

--- a/app/Model/User/Entity/PaymentGroupVisit.php
+++ b/app/Model/User/Entity/PaymentGroupVisit.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\User\Entity;
+
+use App\Model\Infrastructure\Entity\AbstractIdEntity;
+use DateTimeImmutable;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Index;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\UniqueConstraint;
+use InvalidArgumentException;
+
+#[Entity(repositoryClass: \App\Model\User\Repository\PaymentGroupVisitRepository::class)]
+#[Table(name: 'payment_group_visit')]
+#[UniqueConstraint(name: 'payment_group_visit_user_group_unique', columns: ['user_id', 'group_id'])]
+#[Index(name: 'payment_group_visit_user_visited_idx', columns: ['user_id', 'visited_at'])]
+class PaymentGroupVisit extends AbstractIdEntity
+{
+    #[Column(name: 'user_id', type: Types::INTEGER, options: ['unsigned' => true])]
+    private int $userId;
+
+    #[Column(name: 'group_id', type: Types::INTEGER, options: ['unsigned' => true])]
+    private int $groupId;
+
+    #[Column(name: 'visited_at', type: Types::DATETIME_IMMUTABLE)]
+    private DateTimeImmutable $visitedAt;
+
+    public function __construct(int $userId, int $groupId, ?DateTimeImmutable $visitedAt = null)
+    {
+        if ($userId < 1) {
+            throw new InvalidArgumentException('Payment group visit user_id must be a positive integer.');
+        }
+
+        if ($groupId < 1) {
+            throw new InvalidArgumentException('Payment group visit group_id must be a positive integer.');
+        }
+
+        $this->userId = $userId;
+        $this->groupId = $groupId;
+        $this->visitedAt = $visitedAt ?? new DateTimeImmutable();
+    }
+
+    public function markVisited(?DateTimeImmutable $visitedAt = null): void
+    {
+        $this->visitedAt = $visitedAt ?? new DateTimeImmutable();
+    }
+
+    public function getUserId(): int
+    {
+        return $this->userId;
+    }
+
+    public function getGroupId(): int
+    {
+        return $this->groupId;
+    }
+
+    public function getVisitedAt(): DateTimeImmutable
+    {
+        return $this->visitedAt;
+    }
+}

--- a/app/Model/User/Manager/PaymentGroupVisitManager.php
+++ b/app/Model/User/Manager/PaymentGroupVisitManager.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\User\Manager;
+
+use App\Model\Infrastructure\Manager\AbstractManager;
+use App\Model\User\Entity\PaymentGroupVisit;
+use App\Model\User\Repository\PaymentGroupVisitRepository;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+
+class PaymentGroupVisitManager extends AbstractManager
+{
+    private const MAX_VISITS_PER_USER = 3;
+
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        private PaymentGroupVisitRepository $repository,
+    ) {
+        parent::__construct($entityManager);
+    }
+
+    public function getEntityClass(): string
+    {
+        return PaymentGroupVisit::class;
+    }
+
+    public function markVisited(int $userId, int $groupId): PaymentGroupVisit
+    {
+        return $this->em->wrapInTransaction(function () use ($userId, $groupId): PaymentGroupVisit {
+            $visit = $this->repository->findOneByUserIdAndGroupId($userId, $groupId)
+                ?? new PaymentGroupVisit($userId, $groupId);
+
+            $visit->markVisited(new DateTimeImmutable());
+            $this->em->persist($visit);
+            $this->em->flush();
+            $this->repository->deleteVisitsOverLimit($userId, self::MAX_VISITS_PER_USER);
+
+            return $visit;
+        });
+    }
+}

--- a/app/Model/User/Repository/PaymentGroupVisitRepository.php
+++ b/app/Model/User/Repository/PaymentGroupVisitRepository.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\User\Repository;
+
+use App\Model\Infrastructure\Repository\AbstractRepository;
+use App\Model\Payment\Group;
+use App\Model\User\Entity\PaymentGroupVisit;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\ORM\EntityManagerInterface;
+
+use function array_map;
+
+class PaymentGroupVisitRepository extends AbstractRepository
+{
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        parent::__construct($entityManager);
+    }
+
+    public function getEntityClass(): string
+    {
+        return PaymentGroupVisit::class;
+    }
+
+    public function findOneByUserIdAndGroupId(int $userId, int $groupId): ?PaymentGroupVisit
+    {
+        /** @var PaymentGroupVisit|null $visit */
+        $visit = $this->findOneBy(['userId' => $userId, 'groupId' => $groupId]);
+
+        return $visit;
+    }
+
+    /**
+     * @param int[] $unitIds
+     *
+     * @return Group[]
+     */
+    public function findRecentlyVisitedGroups(int $userId, array $unitIds, int $limit): array
+    {
+        if ($unitIds === [] || $limit < 1) {
+            return [];
+        }
+
+        $groupIds = $this->entityManager->getConnection()
+            ->executeQuery(
+                'SELECT v.group_id
+                    FROM payment_group_visit v
+                    WHERE v.user_id = ?
+                        AND EXISTS (
+                            SELECT 1
+                            FROM pa_group_unit gu
+                            WHERE gu.group_id = v.group_id
+                                AND gu.unit_id IN (?)
+                        )
+                    ORDER BY v.visited_at DESC, v.id DESC
+                    LIMIT ?',
+                [$userId, $unitIds, $limit],
+                [ParameterType::INTEGER, Connection::PARAM_INT_ARRAY, ParameterType::INTEGER],
+            )
+            ->fetchFirstColumn();
+        $groupIds = array_map('intval', $groupIds);
+
+        if ($groupIds === []) {
+            return [];
+        }
+
+        /** @var array<int, Group> $groupsById */
+        $groupsById = $this->entityManager->createQueryBuilder()
+            ->select('g')
+            ->from(Group::class, 'g', 'g.id')
+            ->where('g.id IN (:groupIds)')
+            ->setParameter('groupIds', $groupIds)
+            ->getQuery()
+            ->getResult();
+
+        $groups = [];
+        foreach ($groupIds as $groupId) {
+            if (isset($groupsById[$groupId])) {
+                $groups[] = $groupsById[$groupId];
+            }
+        }
+
+        return $groups;
+    }
+
+    public function deleteVisitsOverLimit(int $userId, int $limit): void
+    {
+        if ($limit < 1) {
+            $this->entityManager->getConnection()->delete('payment_group_visit', ['user_id' => $userId]);
+
+            return;
+        }
+
+        $this->entityManager->getConnection()
+            ->executeStatement(
+                'DELETE FROM payment_group_visit
+                    WHERE user_id = ?
+                        AND id NOT IN (
+                            SELECT id FROM (
+                                SELECT id
+                                FROM payment_group_visit
+                                WHERE user_id = ?
+                                ORDER BY visited_at DESC, id DESC
+                                LIMIT ?
+                            ) recent_visits
+                        )',
+                [$userId, $userId, $limit],
+                [ParameterType::INTEGER, ParameterType::INTEGER, ParameterType::INTEGER],
+            );
+    }
+}

--- a/app/Presentation/Admin/BugReports/BugReportsPresenter.php
+++ b/app/Presentation/Admin/BugReports/BugReportsPresenter.php
@@ -172,12 +172,12 @@ final class BugReportsPresenter extends \App\Presentation\Admin\AdminBasePresent
         $grid->addAction('detail', '', 'detail', ['id' => 'id'])
             ->setIcon('far fa-eye')
             ->setTitle('Zobrazit detail')
-            ->setClass('btn btn-sm btn-light')
+            ->setClass('btn btn-sm btn-light m-1')
             ->setDataAttribute('test', 'admin-bug-report-detail-grid');
         $grid->addAction('resolve', '', 'resolve!', ['id' => 'id'])
             ->setIcon('far fa-circle-check')
             ->setTitle('Potvrdit opravu')
-            ->setClass('btn btn-sm btn-outline-success')
+            ->setClass('btn btn-sm btn-outline-success m-1')
             ->setDataAttribute('test', 'admin-bug-report-resolve-grid')
             ->setConfirmation(
                 new StringConfirmation('Opravdu chcete potvrdit opravu hlášení #%s?', 'id'),

--- a/app/Presentation/Payments/Dashboard/DashboardPresenter.php
+++ b/app/Presentation/Payments/Dashboard/DashboardPresenter.php
@@ -12,6 +12,7 @@ use App\Model\Invoice\Repository\InvoiceSequenceRepository;
 use App\Model\Payment\Payment\State;
 use App\Model\Payment\PaymentService;
 use App\Model\Payment\ReadModel\Queries\GetGroupList;
+use App\Model\Payment\ReadModel\Queries\RecentlyVisitedGroupsQuery;
 use App\Presentation\Payments\PaymentsBasePresenter;
 
 use function array_keys;
@@ -34,14 +35,17 @@ final class DashboardPresenter extends PaymentsBasePresenter
         $readableUnitIds = array_keys($this->unitService->getReadUnits($this->user));
         $currentYear = (int) date('Y');
 
-        // Payment groups — last 2 open
         /** @var Group[] $allGroups */
-        $allGroups = $this->queryBus->handle(new GetGroupList($readableUnitIds, true));
-        usort(
-            $allGroups,
-            static fn (Group $first, Group $second): int => $second->getId() <=> $first->getId(),
-        );
-        $groups = array_slice($allGroups, 0, 2);
+        $allGroups = $this->queryBus->handle(new GetGroupList($readableUnitIds, false));
+        /** @var Group[] $groups */
+        $groups = $this->queryBus->handle(new RecentlyVisitedGroupsQuery((int) $this->getUser()->getId(), $readableUnitIds, 3));
+        if ($groups === []) {
+            usort(
+                $allGroups,
+                static fn (Group $first, Group $second): int => $second->getId() <=> $first->getId(),
+            );
+            $groups = array_slice($allGroups, 0, 3);
+        }
         $groupIds = array_map(static fn (Group $group): int => $group->getId(), $groups);
         $groupSummaries = $groupIds === [] ? [] : $this->paymentService->getGroupSummaries($groupIds);
         $groupPaymentCounts = [];

--- a/app/Presentation/Payments/Dashboard/default.latte
+++ b/app/Presentation/Payments/Dashboard/default.latte
@@ -62,7 +62,7 @@
     <section class="card" data-test="dashboard-payment-groups">
         <div class="card-body">
             <div class="d-flex flex-wrap gap-2 align-items-center justify-content-between mb-3">
-                <h2 class="h5 mb-0">Platební skupiny</h2>
+                <h2 class="h5 mb-0">Naposledy navštívené platební skupiny</h2>
                 <div class="d-flex flex-wrap gap-2">
                     <a n:if="$isEditable"
                        n:href=":Payments:Group:newGroup, unitId => $unitId"
@@ -73,7 +73,7 @@
                     </a>
                     <a n:href=":Payments:GroupList:default, unitId => $unitId"
                        class="btn btn-outline-secondary btn-sm">
-                        {if $totalGroupCount > 2}Zobrazit vše ({$totalGroupCount}){else}Zobrazit skupiny{/if}
+                        {if $totalGroupCount > 3}Zobrazit vše ({$totalGroupCount}){else}Zobrazit skupiny{/if}
                     </a>
                 </div>
             </div>
@@ -117,7 +117,7 @@
             </div>
 
             <div n:if="$groups === []" class="border border-dashed rounded-3 p-3 text-body-secondary">
-                Zatím nejsou vytvořeny žádné otevřené platební skupiny.
+                Zatím jste nenavštívili žádnou platební skupinu.
             </div>
         </div>
     </section>

--- a/app/Presentation/Payments/Payment/PaymentPresenter.php
+++ b/app/Presentation/Payments/Payment/PaymentPresenter.php
@@ -36,6 +36,7 @@ use App\Model\Payment\PaymentService;
 use App\Model\Payment\ReadModel\Queries\MembersWithoutPaymentInGroupQuery;
 use App\Model\Payment\ReadModel\Queries\PaymentListQuery;
 use App\Model\Unit\UnitService;
+use App\Model\User\Manager\PaymentGroupVisitManager;
 use App\Presentation\Payments\PaymentsBasePresenter;
 use DateTimeImmutable;
 use Nette\Utils\Strings;
@@ -78,6 +79,7 @@ final class PaymentPresenter extends PaymentsBasePresenter
         private IPaymentNoteDialogFactory $paymentNoteDialogFactory,
         private IPaymentListFactory $paymentListFactory,
         private ISplitPaymentDialogFactory $splitPaymentDialogFactory,
+        private PaymentGroupVisitManager $paymentGroupVisitManager,
     ) {
         parent::__construct();
     }
@@ -104,6 +106,8 @@ final class PaymentPresenter extends PaymentsBasePresenter
         if ($this->canEditGroup($group)) {
             $this['pairButton']->setGroups([$id]);
         }
+
+        $this->paymentGroupVisitManager->markVisited((int) $this->getUser()->getId(), $id);
 
         try {
             $nextVS = $this->model->getNextVS($group->getId());

--- a/migrations/2026/Version20260707150000.php
+++ b/migrations/2026/Version20260707150000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260707150000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add payment group visit history per user';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("CREATE TABLE payment_group_visit (id INT UNSIGNED AUTO_INCREMENT NOT NULL, user_id INT UNSIGNED NOT NULL, group_id INT UNSIGNED NOT NULL, visited_at DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)', UNIQUE INDEX payment_group_visit_user_group_unique (user_id, group_id), INDEX payment_group_visit_user_visited_idx (user_id, visited_at), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_czech_ci` ENGINE = InnoDB");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE payment_group_visit');
+    }
+}

--- a/tests/acceptance/PaymentCest.php
+++ b/tests/acceptance/PaymentCest.php
@@ -320,6 +320,9 @@ class PaymentCest extends BaseAcceptanceCest
             ]);
         }
 
+        $I->amOnPage('/platby/skupiny/'.$groupId.'/platby');
+        $I->waitForElementVisible('[data-test="payment-group-detail-page"]', 10);
+
         $I->amOnPage('/platby');
         $I->waitForElementVisible('[data-test="dashboard-group-card-'.$groupId.'"]', 10);
 

--- a/tests/acceptance/PaymentCest.php
+++ b/tests/acceptance/PaymentCest.php
@@ -347,6 +347,10 @@ class PaymentCest extends BaseAcceptanceCest
         );
         $I->waitForElementVisible('[data-test="payment-group-detail-page"]', 10);
         $I->seeInCurrentUrl('/platby/skupiny/'.$groupId.'/platby');
+        $I->seeInDatabase('payment_group_visit', [
+            'user_id' => self::ACCEPTANCE_USER_ID,
+            'group_id' => $groupId,
+        ]);
     }
 
     /** @group payment */

--- a/tests/integration/User/PaymentGroupVisitRepositoryTest.php
+++ b/tests/integration/User/PaymentGroupVisitRepositoryTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\User\Repository;
+
+use App\Model\Payment\Group;
+use App\Model\User\Entity\PaymentGroupVisit;
+use App\Model\User\Manager\PaymentGroupVisitManager;
+use IntegrationTest;
+
+class PaymentGroupVisitRepositoryTest extends IntegrationTest
+{
+    private PaymentGroupVisitRepository $repository;
+
+    /** @return string[] */
+    public function getTestedAggregateRoots(): array
+    {
+        return [
+            Group::class,
+            PaymentGroupVisit::class,
+        ];
+    }
+
+    protected function _before(): void
+    {
+        $this->tester->useConfigFiles(['config/doctrine.neon']);
+
+        parent::_before();
+
+        $this->repository = new PaymentGroupVisitRepository($this->entityManager);
+    }
+
+    public function testFindRecentlyVisitedGroupsReturnsAccessibleGroupsForUserOrderedByVisit(): void
+    {
+        $this->createGroup(1, 10);
+        $this->createGroup(2, 10);
+        $this->createGroup(3, 10);
+        $this->createGroup(4, 10);
+        $this->createGroup(5, 99);
+
+        $this->createVisit(2465, 1, '2026-07-07 10:00:00');
+        $this->createVisit(2465, 2, '2026-07-07 12:00:00');
+        $this->createVisit(2465, 3, '2026-07-07 11:00:00');
+        $this->createVisit(1942, 4, '2026-07-07 13:00:00');
+        $this->createVisit(2465, 5, '2026-07-07 14:00:00');
+
+        $groups = $this->repository->findRecentlyVisitedGroups(2465, [10], 3);
+
+        self::assertSame([2, 3, 1], array_map(static fn (Group $group): int => $group->getId(), $groups));
+    }
+
+    public function testDeleteVisitsOverLimitKeepsOnlyNewestUserVisits(): void
+    {
+        $this->createGroup(1, 10);
+        $this->createGroup(2, 10);
+        $this->createGroup(3, 10);
+        $this->createGroup(4, 10);
+        $this->createGroup(5, 10);
+
+        $this->createVisit(2465, 1, '2026-07-07 10:00:00');
+        $this->createVisit(2465, 2, '2026-07-07 11:00:00');
+        $this->createVisit(2465, 3, '2026-07-07 12:00:00');
+        $this->createVisit(2465, 4, '2026-07-07 13:00:00');
+        $this->createVisit(1942, 5, '2026-07-07 14:00:00');
+
+        $this->repository->deleteVisitsOverLimit(2465, 3);
+
+        self::assertSame(3, (int) $this->tester->grabNumRecords('payment_group_visit', ['user_id' => 2465]));
+        $this->tester->dontSeeInDatabase('payment_group_visit', ['user_id' => 2465, 'group_id' => 1]);
+        $this->tester->seeInDatabase('payment_group_visit', ['user_id' => 2465, 'group_id' => 2]);
+        $this->tester->seeInDatabase('payment_group_visit', ['user_id' => 2465, 'group_id' => 3]);
+        $this->tester->seeInDatabase('payment_group_visit', ['user_id' => 2465, 'group_id' => 4]);
+        $this->tester->seeInDatabase('payment_group_visit', ['user_id' => 1942, 'group_id' => 5]);
+    }
+
+    public function testManagerKeepsOnlyThreeVisitsPerUser(): void
+    {
+        $manager = new PaymentGroupVisitManager($this->entityManager, $this->repository);
+
+        $this->createGroup(1, 10);
+        $this->createGroup(2, 10);
+        $this->createGroup(3, 10);
+        $this->createGroup(4, 10);
+
+        $manager->markVisited(2465, 1);
+        $manager->markVisited(2465, 2);
+        $manager->markVisited(2465, 3);
+        $manager->markVisited(2465, 4);
+
+        self::assertSame(3, (int) $this->tester->grabNumRecords('payment_group_visit', ['user_id' => 2465]));
+        $this->tester->dontSeeInDatabase('payment_group_visit', ['user_id' => 2465, 'group_id' => 1]);
+        $this->tester->seeInDatabase('payment_group_visit', ['user_id' => 2465, 'group_id' => 2]);
+        $this->tester->seeInDatabase('payment_group_visit', ['user_id' => 2465, 'group_id' => 3]);
+        $this->tester->seeInDatabase('payment_group_visit', ['user_id' => 2465, 'group_id' => 4]);
+    }
+
+    private function createGroup(int $id, int $unitId): void
+    {
+        $this->tester->haveInDatabase('pa_group', [
+            'id' => $id,
+            'name' => 'Test '.$id,
+            'state' => Group::STATE_OPEN,
+            'note' => '',
+            'created_at' => '2026-07-07 09:00:00',
+            'last_pairing' => null,
+            'oauth_id' => null,
+            'bank_account_id' => null,
+            'amount' => 100.0,
+            'next_variable_symbol' => '100',
+            'due_date' => '2026-07-08',
+            'constant_symbol' => null,
+        ]);
+
+        $this->tester->haveInDatabase('pa_group_unit', [
+            'group_id' => $id,
+            'unit_id' => $unitId,
+        ]);
+    }
+
+    private function createVisit(int $userId, int $groupId, string $visitedAt): void
+    {
+        $this->tester->haveInDatabase('payment_group_visit', [
+            'user_id' => $userId,
+            'group_id' => $groupId,
+            'visited_at' => $visitedAt,
+        ]);
+    }
+}


### PR DESCRIPTION
- Added functionality to track user visits to payment groups with a limit of 3 recent visits.
- Updated dashboard to prioritize recently visited groups over open payment groups.
- Implemented `PaymentGroupVisitManager` and `PaymentGroupVisitRepository` for visit management.
- Added `RecentlyVisitedGroupsQuery` and corresponding data handling.
- Updated UI with relevant messaging and group display adjustments.
- Included database migration to support payment group visit tracking.
- Added integration and acceptance tests for visit tracking and dashboard behavior.