### PR TITLE
feat: enforce public and protected page 

### DIFF
--- a/app/Model/Skautis/Auth/SkautisAuthorizator.php
+++ b/app/Model/Skautis/Auth/SkautisAuthorizator.php
@@ -11,7 +11,6 @@ use App\Model\Auth\Resources\Event;
 use App\Model\Auth\Resources\Grant;
 use App\Model\Auth\Resources\Unit;
 use InvalidArgumentException;
-use Skautis\User;
 use Skautis\Wsdl\PermissionException;
 use Skautis\Wsdl\WebServiceInterface;
 use stdClass;
@@ -29,7 +28,7 @@ final class SkautisAuthorizator implements IAuthorizator
         Unit::class => Unit::TABLE,
     ];
 
-    public function __construct(private WebServiceInterface $userWebservice, private User $user)
+    public function __construct(private WebServiceInterface $userWebservice)
     {
     }
 
@@ -54,10 +53,6 @@ final class SkautisAuthorizator implements IAuthorizator
     /** @return stdClass[] */
     private function getAvailableActions(string $skautisTable, ?int $id): array
     {
-        if ($this->user->getLoginId() === null) {
-            return [];
-        }
-
         $arguments = ['ID_Table' => $skautisTable];
         if ($id !== null) {
             $arguments['ID'] = $id;

--- a/app/Model/Skautis/Auth/SkautisAuthorizator.php
+++ b/app/Model/Skautis/Auth/SkautisAuthorizator.php
@@ -11,6 +11,7 @@ use App\Model\Auth\Resources\Event;
 use App\Model\Auth\Resources\Grant;
 use App\Model\Auth\Resources\Unit;
 use InvalidArgumentException;
+use Skautis\User;
 use Skautis\Wsdl\PermissionException;
 use Skautis\Wsdl\WebServiceInterface;
 use stdClass;
@@ -28,7 +29,7 @@ final class SkautisAuthorizator implements IAuthorizator
         Unit::class => Unit::TABLE,
     ];
 
-    public function __construct(private WebServiceInterface $userWebservice)
+    public function __construct(private WebServiceInterface $userWebservice, private User $user)
     {
     }
 
@@ -53,12 +54,17 @@ final class SkautisAuthorizator implements IAuthorizator
     /** @return stdClass[] */
     private function getAvailableActions(string $skautisTable, ?int $id): array
     {
+        if ($this->user->getLoginId() === null) {
+            return [];
+        }
+
+        $arguments = ['ID_Table' => $skautisTable];
+        if ($id !== null) {
+            $arguments['ID'] = $id;
+        }
+
         try {
-            $result = $this->userWebservice->ActionVerify([
-                'ID' => $id,
-                'ID_Table' => $skautisTable,
-                'ID_Action' => null,
-            ]);
+            $result = $this->userWebservice->ActionVerify($arguments);
 
             return is_array($result)
                 ? $result

--- a/app/Presentation/Events/Default/DefaultPresenter.php
+++ b/app/Presentation/Events/Default/DefaultPresenter.php
@@ -20,7 +20,7 @@ use Skautis\Exception;
 use function array_merge;
 use function sprintf;
 
-final class DefaultPresenter extends \App\BasePresenter
+final class DefaultPresenter extends \App\Presentation\Events\BasePresenter
 {
     public const DEFAULT_STATE = 'draft';
 

--- a/app/config/skautis.neon
+++ b/app/config/skautis.neon
@@ -5,7 +5,7 @@ skautis:
 services:
     # Skautis authorizator
     skautisAuthorizator:
-        factory: App\Model\Skautis\Auth\SkautisAuthorizator(@skautis.webservice.user)
+        factory: App\Model\Skautis\Auth\SkautisAuthorizator(@skautis.webservice.user, @skautis.user)
         autowired: false
 
     # Skautis cache

--- a/app/config/skautis.neon
+++ b/app/config/skautis.neon
@@ -5,7 +5,7 @@ skautis:
 services:
     # Skautis authorizator
     skautisAuthorizator:
-        factory: App\Model\Skautis\Auth\SkautisAuthorizator(@skautis.webservice.user, @skautis.user)
+        factory: App\Model\Skautis\Auth\SkautisAuthorizator(@skautis.webservice.user)
         autowired: false
 
     # Skautis cache

--- a/app/presenters/BasePresenter.php
+++ b/app/presenters/BasePresenter.php
@@ -34,16 +34,24 @@ use function array_key_last;
 use function assert;
 use function dirname;
 use function explode;
+use function in_array;
 use function is_file;
 use function preg_match;
 use function sprintf;
 use function str_contains;
 use function str_replace;
+use function strtolower;
 
 /** @property DefaultTemplate $template */
 abstract class BasePresenter extends Presenter
 {
     private const SESSION_KEEP_ALIVE_INTERVAL_MS = 1_200_000;
+
+    private const PUBLIC_ACTIONS = [
+        'Default' => ['default', 'about', 'reinforcement'],
+    ];
+
+    private const AUTH_ACTIONS = ['ajax', 'default', 'logonskautis', 'logoutsis', 'skautis', 'skautislogout'];
 
     protected UserService $userService;
 
@@ -126,6 +134,15 @@ abstract class BasePresenter extends Presenter
 
         if ($this->getUser()->isLoggedIn() && $backlink !== null) {
             $this->restoreRequest($backlink);
+        }
+
+        if (! $this->getUser()->isLoggedIn() && ! $this->isPublicRequest()) {
+            $backlink = $this->storeRequest('+ 3 days');
+            if ($this->isAjax()) {
+                $this->forward(':Auth:ajax', ['backlink' => $backlink]);
+            }
+
+            $this->redirect(':Default:', ['backlink' => $backlink]);
         }
 
         try {
@@ -231,6 +248,15 @@ abstract class BasePresenter extends Presenter
         assert($identity instanceof SimpleIdentity);
 
         $identity->access = $this->userService->getAccessArrays($this->unitService);
+    }
+
+    private function isPublicRequest(): bool
+    {
+        if ($this->getName() === 'Auth') {
+            return in_array(strtolower($this->getAction()), self::AUTH_ACTIONS, true);
+        }
+
+        return in_array($this->getAction(), self::PUBLIC_ACTIONS[$this->getName()] ?? [], true);
     }
 
     /**

--- a/tests/acceptance/PublicAccessCest.php
+++ b/tests/acceptance/PublicAccessCest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace acceptance;
+
+use AcceptanceTester;
+use PHPUnit\Framework\Assert;
+
+final class PublicAccessCest extends BaseAcceptanceCest
+{
+    /** @dataProvider publicPages */
+    public function publicPagesRemainAccessible(AcceptanceTester $I, \Codeception\Example $example): void
+    {
+        $I->amOnPage($example['url']);
+        $I->waitForElementVisible($example['selector'], 10);
+    }
+
+    /** @dataProvider protectedPages */
+    public function protectedPagesRedirectAnonymousUsersToHomepage(AcceptanceTester $I, \Codeception\Example $example): void
+    {
+        $I->amOnPage($example['url']);
+        $I->waitForElementVisible('[data-test="homepage"]', 10);
+        Assert::assertSame('/', parse_url($I->grabFromCurrentUrl(), PHP_URL_PATH));
+    }
+
+    /**
+     * @return array<string, array{url: string, selector: string}>
+     */
+    protected function publicPages(): array
+    {
+        return [
+            'homepage' => ['url' => '/', 'selector' => '[data-test="homepage"]'],
+            'about' => ['url' => '/o-projektu', 'selector' => 'h1'],
+            'reinforcement' => ['url' => '/posily', 'selector' => 'h1'],
+        ];
+    }
+
+    /**
+     * @return array<string, array{url: string}>
+     */
+    protected function protectedPages(): array
+    {
+        return [
+            'events' => ['url' => '/akce'],
+            'bug-report' => ['url' => '/nahlasit-problem'],
+            'download' => ['url' => '/cestaky/vozidla/download-scan/77?path=scan.pdf'],
+        ];
+    }
+}

--- a/tests/unit/Auth/CompositeAuthorizatorTest.php
+++ b/tests/unit/Auth/CompositeAuthorizatorTest.php
@@ -18,9 +18,7 @@ use Mockery;
 use Nette\Security\IUserStorage;
 use Nette\Security\SimpleIdentity;
 use Nette\Security\User;
-use Skautis\User as SkautisUser;
 use Skautis\Wsdl\WebServiceInterface;
-use Skautis\Wsdl\WsdlManager;
 use stdClass;
 
 final class CompositeAuthorizatorTest extends Unit
@@ -38,7 +36,7 @@ final class CompositeAuthorizatorTest extends Unit
 
         $adminAccessChecker = new AdminAccessChecker($this->mockUser(1942), $repository, []);
         $authorizator = new CompositeAuthorizator(
-            new SkautisAuthorizator($webservice, $this->skautisUser(null)),
+            new SkautisAuthorizator($webservice),
             $adminAccessChecker,
             $this->invoiceAccessChecker(),
         );
@@ -61,7 +59,7 @@ final class CompositeAuthorizatorTest extends Unit
             ->andReturn(true);
 
         $authorizator = new CompositeAuthorizator(
-            new SkautisAuthorizator($webservice, $this->skautisUser(null)),
+            new SkautisAuthorizator($webservice),
             new AdminAccessChecker($this->mockUser(null), $adminRepository, []),
             new InvoiceAccessChecker($this->mockUser(1942), $invoiceRepository, []),
         );
@@ -88,22 +86,12 @@ final class CompositeAuthorizatorTest extends Unit
 
         $adminAccessChecker = new AdminAccessChecker($this->mockUser(null), $repository, []);
         $authorizator = new CompositeAuthorizator(
-            new SkautisAuthorizator($webservice, $this->skautisUser('00000000-0000-0000-0000-000000000000')),
+            new SkautisAuthorizator($webservice),
             $adminAccessChecker,
             $this->invoiceAccessChecker(),
         );
 
         self::assertTrue($authorizator->isAllowed(UnitResource::EDIT, 123));
-    }
-
-    public function testSkautisAuthorizatorReturnsFalseWithoutSkautisLogin(): void
-    {
-        $webservice = Mockery::mock(WebServiceInterface::class);
-        $webservice->shouldNotReceive('ActionVerify');
-
-        $authorizator = new SkautisAuthorizator($webservice, $this->skautisUser(null));
-
-        self::assertFalse($authorizator->isAllowed(UnitResource::EDIT, 123));
     }
 
     public function testSkautisAuthorizatorOmitsOptionalNullSoapArguments(): void
@@ -119,10 +107,7 @@ final class CompositeAuthorizatorTest extends Unit
             ])
             ->andReturn([$allowedAction]);
 
-        $authorizator = new SkautisAuthorizator(
-            $webservice,
-            $this->skautisUser('00000000-0000-0000-0000-000000000000'),
-        );
+        $authorizator = new SkautisAuthorizator($webservice);
 
         self::assertTrue($authorizator->isAllowed(EventResource::CREATE, null));
     }
@@ -146,13 +131,5 @@ final class CompositeAuthorizatorTest extends Unit
             ->andReturn(null);
 
         return new User($storage);
-    }
-
-    private function skautisUser(?string $loginId): SkautisUser
-    {
-        $user = new SkautisUser(Mockery::mock(WsdlManager::class));
-        $user->setLoginData($loginId);
-
-        return $user;
     }
 }

--- a/tests/unit/Auth/CompositeAuthorizatorTest.php
+++ b/tests/unit/Auth/CompositeAuthorizatorTest.php
@@ -6,6 +6,7 @@ namespace App\Model\Auth;
 
 use App\Model\Admin\Services\AdminAccessChecker;
 use App\Model\Auth\Resources\Admin;
+use App\Model\Auth\Resources\Event as EventResource;
 use App\Model\Auth\Resources\InvoiceAccess;
 use App\Model\Auth\Resources\Unit as UnitResource;
 use App\Model\Invoice\InvoiceAccessChecker;
@@ -17,7 +18,9 @@ use Mockery;
 use Nette\Security\IUserStorage;
 use Nette\Security\SimpleIdentity;
 use Nette\Security\User;
+use Skautis\User as SkautisUser;
 use Skautis\Wsdl\WebServiceInterface;
+use Skautis\Wsdl\WsdlManager;
 use stdClass;
 
 final class CompositeAuthorizatorTest extends Unit
@@ -35,7 +38,7 @@ final class CompositeAuthorizatorTest extends Unit
 
         $adminAccessChecker = new AdminAccessChecker($this->mockUser(1942), $repository, []);
         $authorizator = new CompositeAuthorizator(
-            new SkautisAuthorizator($webservice),
+            new SkautisAuthorizator($webservice, $this->skautisUser(null)),
             $adminAccessChecker,
             $this->invoiceAccessChecker(),
         );
@@ -58,7 +61,7 @@ final class CompositeAuthorizatorTest extends Unit
             ->andReturn(true);
 
         $authorizator = new CompositeAuthorizator(
-            new SkautisAuthorizator($webservice),
+            new SkautisAuthorizator($webservice, $this->skautisUser(null)),
             new AdminAccessChecker($this->mockUser(null), $adminRepository, []),
             new InvoiceAccessChecker($this->mockUser(1942), $invoiceRepository, []),
         );
@@ -77,7 +80,6 @@ final class CompositeAuthorizatorTest extends Unit
             ->with([
                 'ID' => 123,
                 'ID_Table' => 'OU_Unit',
-                'ID_Action' => null,
             ])
             ->andReturn([$allowedAction]);
 
@@ -86,12 +88,43 @@ final class CompositeAuthorizatorTest extends Unit
 
         $adminAccessChecker = new AdminAccessChecker($this->mockUser(null), $repository, []);
         $authorizator = new CompositeAuthorizator(
-            new SkautisAuthorizator($webservice),
+            new SkautisAuthorizator($webservice, $this->skautisUser('00000000-0000-0000-0000-000000000000')),
             $adminAccessChecker,
             $this->invoiceAccessChecker(),
         );
 
         self::assertTrue($authorizator->isAllowed(UnitResource::EDIT, 123));
+    }
+
+    public function testSkautisAuthorizatorReturnsFalseWithoutSkautisLogin(): void
+    {
+        $webservice = Mockery::mock(WebServiceInterface::class);
+        $webservice->shouldNotReceive('ActionVerify');
+
+        $authorizator = new SkautisAuthorizator($webservice, $this->skautisUser(null));
+
+        self::assertFalse($authorizator->isAllowed(UnitResource::EDIT, 123));
+    }
+
+    public function testSkautisAuthorizatorOmitsOptionalNullSoapArguments(): void
+    {
+        $allowedAction = new stdClass();
+        $allowedAction->ID = EventResource::CREATE[1];
+
+        $webservice = Mockery::mock(WebServiceInterface::class);
+        $webservice->shouldReceive('ActionVerify')
+            ->once()
+            ->with([
+                'ID_Table' => 'EV_EventGeneral',
+            ])
+            ->andReturn([$allowedAction]);
+
+        $authorizator = new SkautisAuthorizator(
+            $webservice,
+            $this->skautisUser('00000000-0000-0000-0000-000000000000'),
+        );
+
+        self::assertTrue($authorizator->isAllowed(EventResource::CREATE, null));
     }
 
     private function invoiceAccessChecker(): InvoiceAccessChecker
@@ -113,5 +146,13 @@ final class CompositeAuthorizatorTest extends Unit
             ->andReturn(null);
 
         return new User($storage);
+    }
+
+    private function skautisUser(?string $loginId): SkautisUser
+    {
+        $user = new SkautisUser(Mockery::mock(WsdlManager::class));
+        $user->setLoginData($loginId);
+
+        return $user;
     }
 }


### PR DESCRIPTION
…hentication

- Added `PublicAccessCest` acceptance tests for verifying public pages remain accessible and protected pages redirect anonymous users.
- Extended `SkautisAuthorizator` to handle user login ID checks and streamline Skautis SOAP arguments.
- Updated `BasePresenter` to redirect unauthenticated users from protected pages and define public actions.
- Introduced `isPublicRequest` method for action-specific access checks.
- Enhanced unit tests to cover additional authentication scenarios and Skautis behavior.