### PR TITLE
feat: add support for remembering SkautIS roles in user preferences

### DIFF
--- a/app/Components/LoginPanel.php
+++ b/app/Components/LoginPanel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Components;
 
 use App\Model\Unit\UnitService;
+use App\Model\User\UserPreferencesService;
 use App\Model\User\UserService;
 use Nette\Security\SimpleIdentity;
 use Nette\Security\User;
@@ -16,6 +17,7 @@ final class LoginPanel extends BaseControl
     public function __construct(
         private UserService $userService,
         private UnitService $unitService,
+        private UserPreferencesService $preferences,
         private User $user,
     ) {
     }
@@ -23,6 +25,10 @@ final class LoginPanel extends BaseControl
     public function handleChangeRole(int $roleId): void
     {
         $this->userService->updateSkautISRole($roleId);
+        $currentRoleId = $this->userService->getRoleId();
+        if ($currentRoleId !== null) {
+            $this->preferences->rememberCurrentSkautisRole($currentRoleId);
+        }
 
         $identity = $this->user->getIdentity();
 

--- a/app/Model/User/Entity/UserPreference.php
+++ b/app/Model/User/Entity/UserPreference.php
@@ -27,6 +27,12 @@ class UserPreference extends AbstractIdEntity
     #[Column(name: 'extend_skautis_login', type: Types::BOOLEAN, options: ['default' => false])]
     private bool $extendSkautisLogin;
 
+    #[Column(name: 'remember_skautis_role', type: Types::BOOLEAN, options: ['default' => false])]
+    private bool $rememberSkautisRole;
+
+    #[Column(name: 'remembered_skautis_role_id', type: Types::INTEGER, nullable: true, options: ['unsigned' => true])]
+    private ?int $rememberedSkautisRoleId;
+
     #[Column(name: 'updated_at', type: Types::DATETIME_IMMUTABLE)]
     private DateTimeImmutable $updatedAt;
 
@@ -34,15 +40,22 @@ class UserPreference extends AbstractIdEntity
         int $userId,
         bool $showHelp = true,
         bool $extendSkautisLogin = false,
+        bool $rememberSkautisRole = false,
+        ?int $rememberedSkautisRoleId = null,
         ?DateTimeImmutable $updatedAt = null,
     ) {
         if ($userId < 1) {
             throw new InvalidArgumentException('User preference user_id must be a positive integer.');
         }
+        if ($rememberedSkautisRoleId !== null && $rememberedSkautisRoleId < 1) {
+            throw new InvalidArgumentException('Remembered SkautIS role id must be a positive integer.');
+        }
 
         $this->userId = $userId;
         $this->showHelp = $showHelp;
         $this->extendSkautisLogin = $extendSkautisLogin;
+        $this->rememberSkautisRole = $rememberSkautisRole;
+        $this->rememberedSkautisRoleId = $rememberSkautisRole ? $rememberedSkautisRoleId : null;
         $this->updatedAt = $updatedAt ?? new DateTimeImmutable();
     }
 
@@ -58,10 +71,39 @@ class UserPreference extends AbstractIdEntity
         $this->updatedAt = new DateTimeImmutable();
     }
 
-    public function updatePreferences(bool $showHelp, bool $extendSkautisLogin): void
+    public function setRememberSkautisRole(bool $rememberSkautisRole): void
+    {
+        $this->rememberSkautisRole = $rememberSkautisRole;
+        if (! $rememberSkautisRole) {
+            $this->rememberedSkautisRoleId = null;
+        }
+        $this->updatedAt = new DateTimeImmutable();
+    }
+
+    public function rememberSkautisRole(int $roleId): void
+    {
+        if ($roleId < 1) {
+            throw new InvalidArgumentException('Remembered SkautIS role id must be a positive integer.');
+        }
+
+        $this->rememberedSkautisRoleId = $roleId;
+        $this->updatedAt = new DateTimeImmutable();
+    }
+
+    public function clearRememberedSkautisRole(): void
+    {
+        $this->rememberedSkautisRoleId = null;
+        $this->updatedAt = new DateTimeImmutable();
+    }
+
+    public function updatePreferences(bool $showHelp, bool $extendSkautisLogin, bool $rememberSkautisRole): void
     {
         $this->showHelp = $showHelp;
         $this->extendSkautisLogin = $extendSkautisLogin;
+        $this->rememberSkautisRole = $rememberSkautisRole;
+        if (! $rememberSkautisRole) {
+            $this->rememberedSkautisRoleId = null;
+        }
         $this->updatedAt = new DateTimeImmutable();
     }
 
@@ -78,6 +120,16 @@ class UserPreference extends AbstractIdEntity
     public function shouldExtendSkautisLogin(): bool
     {
         return $this->extendSkautisLogin;
+    }
+
+    public function shouldRememberSkautisRole(): bool
+    {
+        return $this->rememberSkautisRole;
+    }
+
+    public function getRememberedSkautisRoleId(): ?int
+    {
+        return $this->rememberedSkautisRoleId;
     }
 
     public function getUpdatedAt(): DateTimeImmutable

--- a/app/Model/User/Manager/UserPreferenceManager.php
+++ b/app/Model/User/Manager/UserPreferenceManager.php
@@ -35,11 +35,44 @@ class UserPreferenceManager extends AbstractManager
         });
     }
 
-    public function savePreferences(int $userId, bool $showHelp, bool $extendSkautisLogin): UserPreference
-    {
-        return $this->em->wrapInTransaction(function () use ($userId, $showHelp, $extendSkautisLogin): UserPreference {
+    public function savePreferences(
+        int $userId,
+        bool $showHelp,
+        bool $extendSkautisLogin,
+        bool $rememberSkautisRole,
+    ): UserPreference {
+        return $this->em->wrapInTransaction(function () use (
+            $userId,
+            $showHelp,
+            $extendSkautisLogin,
+            $rememberSkautisRole,
+        ): UserPreference {
             $preference = $this->repository->findOneByUserId($userId) ?? new UserPreference($userId);
-            $preference->updatePreferences($showHelp, $extendSkautisLogin);
+            $preference->updatePreferences($showHelp, $extendSkautisLogin, $rememberSkautisRole);
+            $this->em->persist($preference);
+            $this->em->flush();
+
+            return $preference;
+        });
+    }
+
+    public function saveRememberedSkautisRole(int $userId, int $roleId): UserPreference
+    {
+        return $this->em->wrapInTransaction(function () use ($userId, $roleId): UserPreference {
+            $preference = $this->repository->findOneByUserId($userId) ?? new UserPreference($userId);
+            $preference->rememberSkautisRole($roleId);
+            $this->em->persist($preference);
+            $this->em->flush();
+
+            return $preference;
+        });
+    }
+
+    public function clearRememberedSkautisRole(int $userId): UserPreference
+    {
+        return $this->em->wrapInTransaction(function () use ($userId): UserPreference {
+            $preference = $this->repository->findOneByUserId($userId) ?? new UserPreference($userId);
+            $preference->clearRememberedSkautisRole();
             $this->em->persist($preference);
             $this->em->flush();
 

--- a/app/Model/User/UserPreferencesService.php
+++ b/app/Model/User/UserPreferencesService.php
@@ -10,6 +10,7 @@ use Nette\Security\IIdentity;
 use Nette\Security\User;
 use Throwable;
 
+use function in_array;
 use function is_numeric;
 
 final class UserPreferencesService
@@ -49,6 +50,66 @@ final class UserPreferencesService
         }
     }
 
+    public function shouldRememberSkautisRole(): bool
+    {
+        $userId = $this->getCurrentUserId();
+        if ($userId === null) {
+            return false;
+        }
+
+        try {
+            return $this->repository->findOneByUserId($userId)?->shouldRememberSkautisRole() ?? false;
+        } catch (Throwable) {
+            return false;
+        }
+    }
+
+    /**
+     * @param int[] $availableRoleIds
+     */
+    public function getRememberedSkautisRoleIdForLogin(int $userId, array $availableRoleIds): ?int
+    {
+        try {
+            $preference = $this->repository->findOneByUserId($userId);
+            if ($preference === null || ! $preference->shouldRememberSkautisRole()) {
+                return null;
+            }
+
+            $rememberedRoleId = $preference->getRememberedSkautisRoleId();
+            if ($rememberedRoleId === null) {
+                return null;
+            }
+
+            if (in_array($rememberedRoleId, $availableRoleIds, true)) {
+                return $rememberedRoleId;
+            }
+
+            $this->manager->clearRememberedSkautisRole($userId);
+
+            return null;
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    public function rememberCurrentSkautisRole(int $roleId): void
+    {
+        $userId = $this->getCurrentUserId();
+        if ($userId === null) {
+            return;
+        }
+
+        try {
+            $preference = $this->repository->findOneByUserId($userId);
+            if ($preference === null || ! $preference->shouldRememberSkautisRole()) {
+                return;
+            }
+
+            $this->manager->saveRememberedSkautisRole($userId, $roleId);
+        } catch (Throwable) {
+        }
+    }
+
     public function setShowHelp(bool $showHelp): void
     {
         $userId = $this->getCurrentUserId();
@@ -59,14 +120,21 @@ final class UserPreferencesService
         $this->manager->saveHelpVisibility($userId, $showHelp);
     }
 
-    public function setPreferences(bool $showHelp, bool $extendSkautisLogin): void
-    {
+    public function setPreferences(
+        bool $showHelp,
+        bool $extendSkautisLogin,
+        bool $rememberSkautisRole,
+        ?int $currentSkautisRoleId = null,
+    ): void {
         $userId = $this->getCurrentUserId();
         if ($userId === null) {
             return;
         }
 
-        $this->manager->savePreferences($userId, $showHelp, $extendSkautisLogin);
+        $this->manager->savePreferences($userId, $showHelp, $extendSkautisLogin, $rememberSkautisRole);
+        if ($rememberSkautisRole && $currentSkautisRoleId !== null) {
+            $this->manager->saveRememberedSkautisRole($userId, $currentSkautisRoleId);
+        }
     }
 
     public function getCurrentUserId(): ?int

--- a/app/Presentation/Settings/User/UserPresenter.php
+++ b/app/Presentation/Settings/User/UserPresenter.php
@@ -28,10 +28,17 @@ final class UserPresenter extends \App\Presentation\Settings\SettingsBasePresent
             ->setDefaultValue($this->preferences->shouldShowHelp());
         $form->addCheckbox('extendSkautisLogin', 'Na pozadí prodlužovat přihlášení ke skautISu')
             ->setDefaultValue($this->preferences->shouldExtendSkautisLogin());
+        $form->addCheckbox('rememberSkautisRole', 'Pamatovat si zvolenou roli ze skautISu')
+            ->setDefaultValue($this->preferences->shouldRememberSkautisRole());
         $form->addSubmit('save', 'Uložit nastavení');
         $form->onSuccess[] = function (Form $form): void {
             $values = $form->getValues();
-            $this->preferences->setPreferences((bool) $values->showHelp, (bool) $values->extendSkautisLogin);
+            $this->preferences->setPreferences(
+                (bool) $values->showHelp,
+                (bool) $values->extendSkautisLogin,
+                (bool) $values->rememberSkautisRole,
+                $this->userService->getRoleId(),
+            );
             $this->flashMessage('Uživatelské nastavení bylo uloženo.', 'success');
             $this->redirect('this');
         };

--- a/app/Presentation/Settings/User/default.latte
+++ b/app/Presentation/Settings/User/default.latte
@@ -19,7 +19,8 @@
         <div class="card-body" data-test="settings-user-help-form">
             <p class="text-body-secondary">
                 Nastavení se použije pro aktuálně přihlášeného uživatele. Prodloužení přihlášení funguje pouze v době,
-                kdy máte aplikaci otevřenou v prohlížeči, a neodesílá ani nemaže rozpracované formuláře.
+                kdy máte aplikaci otevřenou v prohlížeči, a neodesílá ani nemaže rozpracované formuláře. Zapamatovaná
+                role se použije jen tehdy, pokud ji skautIS při dalším přihlášení stále vrátí mezi dostupnými rolemi.
             </p>
             {control preferencesForm}
         </div>

--- a/app/presenters/AuthPresenter.php
+++ b/app/presenters/AuthPresenter.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace App;
 
 use App\Model\Auth\AuthService;
+use App\Model\User\UserPreferencesService;
 use Nette\Security\SimpleIdentity;
 use Skautis\Wsdl\AuthenticationException;
 
+use function array_map;
 use function strlen;
 use function substr;
 
@@ -15,8 +17,10 @@ class AuthPresenter extends BasePresenter
 {
     protected AuthService $authService;
 
-    public function __construct(AuthService $as)
-    {
+    public function __construct(
+        AuthService $as,
+        private UserPreferencesService $preferences,
+    ) {
         parent::__construct();
 
         $this->authService = $as;
@@ -65,11 +69,20 @@ class AuthPresenter extends BasePresenter
             }
 
             $user = $this->getUser();
+            $userId = (int) $this->userService->getUserDetail()->ID;
+            $roles = $this->userService->getAllSkautisRoles();
+            $rememberedRoleId = $this->preferences->getRememberedSkautisRoleIdForLogin(
+                $userId,
+                array_map(static fn (object $role): int => (int) $role->ID, $roles),
+            );
+            if ($rememberedRoleId !== null && $rememberedRoleId !== $this->userService->getRoleId()) {
+                $this->userService->updateSkautISRole($rememberedRoleId);
+            }
 
             $user->setExpiration('+ 29 minutes'); // nastavíme expiraci
             $user->login(new SimpleIdentity(
-                $this->userService->getUserDetail()->ID,
-                $this->userService->getAllSkautisRoles(),
+                $userId,
+                $roles,
                 ['currentRole' => $this->userService->getActualRole()],
             ));
 

--- a/migrations/2026/Version20260709120000.php
+++ b/migrations/2026/Version20260709120000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260709120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add user preference for remembered SkautIS role';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user_preference ADD remember_skautis_role TINYINT(1) DEFAULT 0 NOT NULL, ADD remembered_skautis_role_id INT UNSIGNED DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user_preference DROP remember_skautis_role, DROP remembered_skautis_role_id');
+    }
+}

--- a/tests/acceptance/SettingsCest.php
+++ b/tests/acceptance/SettingsCest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace acceptance;
 
 use AcceptanceTester;
+use PHPUnit\Framework\Assert;
 
 class SettingsCest extends BaseAcceptanceCest
 {
@@ -254,14 +255,23 @@ class SettingsCest extends BaseAcceptanceCest
 
         $I->dontSeeElement('body[data-session-keep-alive-url]');
         $I->checkOption('input[name="extendSkautisLogin"]');
+        $I->checkOption('input[name="rememberSkautisRole"]');
         $I->click('input[type="submit"]');
         $I->waitForElementVisible('[data-test="settings-user-page"]', 10);
 
         $I->seeInDatabase('user_preference', [
             'user_id' => self::ACCEPTANCE_USER_ID,
             'extend_skautis_login' => 1,
+            'remember_skautis_role' => 1,
         ]);
+        Assert::assertGreaterThan(
+            0,
+            (int) $I->grabFromDatabase('user_preference', 'remembered_skautis_role_id', [
+                'user_id' => self::ACCEPTANCE_USER_ID,
+            ]),
+        );
         $I->seeElement('input[name="extendSkautisLogin"]:checked');
+        $I->seeElement('input[name="rememberSkautisRole"]:checked');
         $I->seeElement('body[data-session-keep-alive-url][data-session-keep-alive-interval]');
     }
 
@@ -323,7 +333,7 @@ class SettingsCest extends BaseAcceptanceCest
                 && darkMatches
                 && document.querySelector('[data-test="settings-bank-account-new-page"] form label.form-label') !== null;
             JS);
-        \PHPUnit\Framework\Assert::assertTrue($labelColorsMatchBodyInBothThemes);
+        Assert::assertTrue($labelColorsMatchBodyInBothThemes);
 
         // Fill form
         $I->fillField('input[name="name"]', 'Testovací účet Selenium');

--- a/tests/unit/User/UserPreferencesServiceTest.php
+++ b/tests/unit/User/UserPreferencesServiceTest.php
@@ -116,12 +116,84 @@ final class UserPreferencesServiceTest extends Unit
 
         $manager = Mockery::mock(UserPreferenceManager::class);
         $manager->shouldReceive('savePreferences')
-            ->with(1942, false, true)
+            ->with(1942, false, true, true)
             ->once()
-            ->andReturn(new UserPreference(1942, false, true));
+            ->andReturn(new UserPreference(1942, false, true, true));
+        $manager->shouldReceive('saveRememberedSkautisRole')
+            ->with(1942, 456)
+            ->once()
+            ->andReturn(new UserPreference(1942, false, true, true, 456));
 
         $service = new UserPreferencesService($this->mockUser(1942), $repository, $manager);
-        $service->setPreferences(false, true);
+        $service->setPreferences(false, true, true, 456);
+    }
+
+    public function testSkautisRoleRememberingIsDisabledByDefault(): void
+    {
+        $repository = Mockery::mock(UserPreferenceRepository::class);
+        $repository->shouldReceive('findOneByUserId')
+            ->with(1942)
+            ->once()
+            ->andReturn(null);
+
+        $manager = Mockery::mock(UserPreferenceManager::class);
+
+        $service = new UserPreferencesService($this->mockUser(1942), $repository, $manager);
+
+        self::assertFalse($service->shouldRememberSkautisRole());
+    }
+
+    public function testRememberedSkautisRoleIsReturnedWhenAvailable(): void
+    {
+        $repository = Mockery::mock(UserPreferenceRepository::class);
+        $repository->shouldReceive('findOneByUserId')
+            ->with(1942)
+            ->once()
+            ->andReturn(new UserPreference(1942, true, false, true, 456));
+
+        $manager = Mockery::mock(UserPreferenceManager::class);
+        $manager->shouldNotReceive('clearRememberedSkautisRole');
+
+        $service = new UserPreferencesService($this->mockUser(null), $repository, $manager);
+
+        self::assertSame(456, $service->getRememberedSkautisRoleIdForLogin(1942, [123, 456]));
+    }
+
+    public function testUnavailableRememberedSkautisRoleIsCleared(): void
+    {
+        $repository = Mockery::mock(UserPreferenceRepository::class);
+        $repository->shouldReceive('findOneByUserId')
+            ->with(1942)
+            ->once()
+            ->andReturn(new UserPreference(1942, true, false, true, 456));
+
+        $manager = Mockery::mock(UserPreferenceManager::class);
+        $manager->shouldReceive('clearRememberedSkautisRole')
+            ->with(1942)
+            ->once()
+            ->andReturn(new UserPreference(1942, true, false, true));
+
+        $service = new UserPreferencesService($this->mockUser(null), $repository, $manager);
+
+        self::assertNull($service->getRememberedSkautisRoleIdForLogin(1942, [123]));
+    }
+
+    public function testChangedSkautisRoleIsRememberedOnlyWhenEnabled(): void
+    {
+        $repository = Mockery::mock(UserPreferenceRepository::class);
+        $repository->shouldReceive('findOneByUserId')
+            ->with(1942)
+            ->once()
+            ->andReturn(new UserPreference(1942, true, false, true));
+
+        $manager = Mockery::mock(UserPreferenceManager::class);
+        $manager->shouldReceive('saveRememberedSkautisRole')
+            ->with(1942, 456)
+            ->once()
+            ->andReturn(new UserPreference(1942, true, false, true, 456));
+
+        $service = new UserPreferencesService($this->mockUser(1942), $repository, $manager);
+        $service->rememberCurrentSkautisRole(456);
     }
 
     private function mockUser(?int $userId): User


### PR DESCRIPTION
- Introduced new user preference options to enable role remembering and persist the selected SkautIS role.
- Implemented logic to validate, store, and clear remembered roles when necessary.
- Enhanced SkautIS authentication to automatically apply remembered roles if valid.
- Updated settings UI to include a checkbox for enabling role remembering.
- Added migration to extend `user_preference` table with fields for storing role preferences.
- Created comprehensive acceptance and unit tests to ensure functionality correctness and edge case handling.