### PR TITLE
feat: integrate GitHub issue management for technical error reports

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -7,6 +7,13 @@ APPLICATION_ID=48104fe2-b447-47f5-9a26-051c710da74e
 # Comma-separated recipients shared by server error notifications and technical error reports.
 # ERROR_EMAILS=admin@example.cz
 
+# Optional GitHub issue integration for technical error reports.
+# Use a fine-grained personal access token with Issues read/write access to this repository.
+# GITHUB_ISSUES_TOKEN=github_pat_...
+# GITHUB_ISSUES_OWNER=skaut
+# GITHUB_ISSUES_REPOSITORY=Skautske-hospodareni
+# GITHUB_ISSUES_LABELS=bug,user-report
+
 # Uncomment when you need custom local credentials or a different database host.
 # DB_HOST=mysql
 # DB_NAME=hskauting

--- a/app/Environment.php
+++ b/app/Environment.php
@@ -201,6 +201,12 @@ final class Environment
                 'credentialsPath' => self::resolvePath($projectDir, $googleCredentialsFile),
                 'redirectUri' => self::getString('GOOGLE_REDIRECT_URI', $baseUrl.'/google/token'),
             ],
+            'github' => [
+                'token' => self::getNullableString('GITHUB_ISSUES_TOKEN'),
+                'owner' => self::getNullableString('GITHUB_ISSUES_OWNER'),
+                'repository' => self::getNullableString('GITHUB_ISSUES_REPOSITORY'),
+                'labels' => self::getList('GITHUB_ISSUES_LABELS'),
+            ],
             'skautis' => [
                 'applicationId' => self::requireString('APPLICATION_ID'),
                 'testMode' => self::getBool('SKAUTIS_TEST_MODE', $appEnv !== 'prod'),

--- a/app/Model/BugReport/Entity/TechnicalErrorReport.php
+++ b/app/Model/BugReport/Entity/TechnicalErrorReport.php
@@ -105,6 +105,18 @@ class TechnicalErrorReport extends AbstractIdEntity
     #[Column(name: 'reply_error', type: Types::TEXT, nullable: true)]
     private ?string $replyError = null;
 
+    #[Column(name: 'github_issue_number', type: Types::INTEGER, nullable: true, options: ['unsigned' => true])]
+    private ?int $githubIssueNumber = null;
+
+    #[Column(name: 'github_issue_url', type: Types::STRING, length: 2048, nullable: true)]
+    private ?string $githubIssueUrl = null;
+
+    #[Column(name: 'github_issue_created_at', type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?DateTimeImmutable $githubIssueCreatedAt = null;
+
+    #[Column(name: 'github_sync_error', type: Types::TEXT, nullable: true)]
+    private ?string $githubSyncError = null;
+
     /** @var Collection&iterable<TechnicalErrorReportReply> */
     #[OneToMany(mappedBy: 'report', targetEntity: TechnicalErrorReportReply::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
     #[OrderBy(['sentAt' => 'DESC', 'id' => 'DESC'])]
@@ -176,15 +188,31 @@ class TechnicalErrorReport extends AbstractIdEntity
         $this->resolutionNotificationError = $error;
     }
 
-    public function markReplySent(string $message, ?DateTimeImmutable $sentAt = null): void
+    public function markReplySent(string $message, ?DateTimeImmutable $sentAt = null): TechnicalErrorReportReply
     {
-        $this->replies->add(new TechnicalErrorReportReply($this, $message, $sentAt));
+        $reply = new TechnicalErrorReportReply($this, $message, $sentAt);
+        $this->replies->add($reply);
         $this->replyError = null;
+
+        return $reply;
     }
 
     public function markReplyFailed(string $error): void
     {
         $this->replyError = $error;
+    }
+
+    public function markGitHubIssueCreated(int $issueNumber, string $issueUrl, ?DateTimeImmutable $createdAt = null): void
+    {
+        $this->githubIssueNumber = $issueNumber;
+        $this->githubIssueUrl = $issueUrl;
+        $this->githubIssueCreatedAt = $createdAt ?? new DateTimeImmutable();
+        $this->githubSyncError = null;
+    }
+
+    public function markGitHubSyncFailed(string $error): void
+    {
+        $this->githubSyncError = $error;
     }
 
     public function resolveAsFixed(?string $message = null, ?DateTimeImmutable $resolvedAt = null): void
@@ -368,5 +396,30 @@ class TechnicalErrorReport extends AbstractIdEntity
     public function wasReplySent(): bool
     {
         return ! $this->replies->isEmpty();
+    }
+
+    public function hasGitHubIssue(): bool
+    {
+        return $this->githubIssueNumber !== null && $this->githubIssueUrl !== null;
+    }
+
+    public function getGitHubIssueNumber(): ?int
+    {
+        return $this->githubIssueNumber;
+    }
+
+    public function getGitHubIssueUrl(): ?string
+    {
+        return $this->githubIssueUrl;
+    }
+
+    public function getGitHubIssueCreatedAt(): ?DateTimeImmutable
+    {
+        return $this->githubIssueCreatedAt;
+    }
+
+    public function getGitHubSyncError(): ?string
+    {
+        return $this->githubSyncError;
     }
 }

--- a/app/Model/BugReport/Entity/TechnicalErrorReportReply.php
+++ b/app/Model/BugReport/Entity/TechnicalErrorReportReply.php
@@ -29,6 +29,12 @@ class TechnicalErrorReportReply extends AbstractIdEntity
     #[Column(name: 'sent_at', type: Types::DATETIME_IMMUTABLE)]
     private DateTimeImmutable $sentAt;
 
+    #[Column(name: 'github_comment_url', type: Types::STRING, length: 2048, nullable: true)]
+    private ?string $githubCommentUrl = null;
+
+    #[Column(name: 'github_comment_error', type: Types::TEXT, nullable: true)]
+    private ?string $githubCommentError = null;
+
     public function __construct(TechnicalErrorReport $report, string $message, ?DateTimeImmutable $sentAt = null)
     {
         $this->report = $report;
@@ -49,5 +55,27 @@ class TechnicalErrorReportReply extends AbstractIdEntity
     public function getSentAt(): DateTimeImmutable
     {
         return $this->sentAt;
+    }
+
+    public function markGitHubCommentCreated(string $commentUrl): void
+    {
+        $this->githubCommentUrl = $commentUrl;
+        $this->githubCommentError = null;
+    }
+
+    public function markGitHubCommentFailed(string $error): void
+    {
+        $this->githubCommentUrl = null;
+        $this->githubCommentError = $error;
+    }
+
+    public function getGitHubCommentUrl(): ?string
+    {
+        return $this->githubCommentUrl;
+    }
+
+    public function getGitHubCommentError(): ?string
+    {
+        return $this->githubCommentError;
     }
 }

--- a/app/Model/BugReport/GitHubIssue.php
+++ b/app/Model/BugReport/GitHubIssue.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\BugReport;
+
+final class GitHubIssue
+{
+    public function __construct(
+        private int $number,
+        private string $url,
+    ) {
+    }
+
+    public function getNumber(): int
+    {
+        return $this->number;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+}

--- a/app/Model/BugReport/GitHubIssueComment.php
+++ b/app/Model/BugReport/GitHubIssueComment.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\BugReport;
+
+final class GitHubIssueComment
+{
+    public function __construct(private string $url)
+    {
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+}

--- a/app/Model/BugReport/GitHubIssueService.php
+++ b/app/Model/BugReport/GitHubIssueService.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\BugReport;
+
+use App\Model\BugReport\Entity\TechnicalErrorReport;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use Nette\Utils\Json;
+use RuntimeException;
+use Throwable;
+
+use function array_filter;
+use function array_values;
+use function implode;
+use function is_array;
+use function is_int;
+use function is_string;
+use function sprintf;
+use function trim;
+
+final class GitHubIssueService
+{
+    private ?string $token;
+
+    private ?string $owner;
+
+    private ?string $repository;
+
+    /** @var list<string> */
+    private array $labels;
+
+    /**
+     * @param array{token?: string|null, owner?: string|null, repository?: string|null, labels?: list<string>} $config
+     */
+    public function __construct(
+        private Client $client,
+        array $config,
+        private string $appBaseUrl,
+    ) {
+        $this->token = $this->normalizeNullableString($config['token'] ?? null);
+        $this->owner = $this->normalizeNullableString($config['owner'] ?? null);
+        $this->repository = $this->normalizeNullableString($config['repository'] ?? null);
+        $this->labels = array_values(array_filter(
+            $config['labels'] ?? [],
+            static fn (mixed $label): bool => is_string($label) && trim($label) !== '',
+        ));
+    }
+
+    public function isConfigured(): bool
+    {
+        return $this->token !== null
+            && $this->owner !== null
+            && $this->repository !== null;
+    }
+
+    public function createIssue(TechnicalErrorReport $report): GitHubIssue
+    {
+        $this->assertConfigured();
+
+        $payload = [
+            'title' => sprintf('Hlášení technické chyby #%d', $report->getId()),
+            'body' => $this->createIssueBody($report),
+        ];
+        if ($this->labels !== []) {
+            $payload['labels'] = $this->labels;
+        }
+
+        $data = $this->request('POST', '/issues', $payload);
+        $number = $data['number'] ?? null;
+        $url = $data['html_url'] ?? null;
+        if (! is_int($number) || ! is_string($url) || $url === '') {
+            throw new RuntimeException('GitHub returned an invalid issue response.');
+        }
+
+        return new GitHubIssue($number, $url);
+    }
+
+    public function addReplyComment(TechnicalErrorReport $report, string $message): GitHubIssueComment
+    {
+        $this->assertConfigured();
+
+        $issueNumber = $report->getGitHubIssueNumber();
+        if ($issueNumber === null) {
+            throw new RuntimeException('Technical error report has no GitHub issue.');
+        }
+
+        $data = $this->request('POST', sprintf('/issues/%d/comments', $issueNumber), [
+            'body' => $this->createReplyCommentBody($report, $message),
+        ]);
+        $url = $data['html_url'] ?? null;
+        if (! is_string($url) || $url === '') {
+            throw new RuntimeException('GitHub returned an invalid comment response.');
+        }
+
+        return new GitHubIssueComment($url);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>
+     */
+    private function request(string $method, string $path, array $payload): array
+    {
+        try {
+            $response = $this->client->request($method, $this->getApiBaseUrl().$path, [
+                'headers' => [
+                    'Accept' => 'application/vnd.github+json',
+                    'Authorization' => 'Bearer '.$this->token,
+                    'User-Agent' => 'skautske-hospodareni',
+                    'X-GitHub-Api-Version' => '2022-11-28',
+                ],
+                'json' => $payload,
+            ]);
+
+            $data = Json::decode((string) $response->getBody(), Json::FORCE_ARRAY);
+            if (! is_array($data)) {
+                throw new RuntimeException('GitHub returned an invalid JSON response.');
+            }
+
+            return $data;
+        } catch (GuzzleException $e) {
+            throw new RuntimeException('GitHub API request failed: '.$e->getMessage(), previous: $e);
+        } catch (Throwable $e) {
+            if ($e instanceof RuntimeException) {
+                throw $e;
+            }
+
+            throw new RuntimeException('GitHub API response could not be processed: '.$e->getMessage(), previous: $e);
+        }
+    }
+
+    private function createIssueBody(TechnicalErrorReport $report): string
+    {
+        $role = array_filter([
+            $report->getRoleName(),
+            $report->getRoleId() !== null ? 'ID '.$report->getRoleId() : null,
+        ]);
+        $unit = array_filter([
+            $report->getUnitName(),
+            $report->getUnitId() !== null ? 'ID '.$report->getUnitId() : null,
+        ]);
+
+        return implode("\n", [
+            'Byla nahlášena technická chyba ve Skautském hospodaření.',
+            '',
+            '## Hlášení',
+            '- Interní ID: #'.$report->getId(),
+            '- Administrace: '.$this->getAdminReportUrl($report),
+            '- Nahlášeno: '.$report->getCreatedAt()->format('Y-m-d H:i:s P'),
+            '- Uživatel: '.$report->getReporterDisplayName().' (ID '.$report->getReporterUserId().')',
+            '- E-mail uživatele: '.($report->getReporterEmail() ?? '-'),
+            '- Role: '.($role !== [] ? implode(', ', $role) : '-'),
+            '- Jednotka: '.($unit !== [] ? implode(', ', $unit) : '-'),
+            '- URL chyby: '.($report->getReportedUrl() ?? '-'),
+            '- Release: '.$report->getAppRelease(),
+            '- Screenshot: '.$this->formatScreenshotReference($report),
+            '',
+            '## Popis',
+            $report->getDescription(),
+            '',
+            '## Diagnostika',
+            '```json',
+            Json::encode($report->getDiagnostics(), JSON_PRETTY_PRINT),
+            '```',
+        ]);
+    }
+
+    private function createReplyCommentBody(TechnicalErrorReport $report, string $message): string
+    {
+        return implode("\n", [
+            'Admin odeslal uživateli odpověď ze systému.',
+            '',
+            'Interní hlášení: '.$this->getAdminReportUrl($report),
+            '',
+            '```',
+            $message,
+            '```',
+        ]);
+    }
+
+    private function formatScreenshotReference(TechnicalErrorReport $report): string
+    {
+        if (! $report->hasScreenshot()) {
+            return '-';
+        }
+
+        return sprintf(
+            '%s (%s/admin/hlaseni-chyb/%d?do=downloadScreenshot)',
+            $report->getScreenshotOriginalName() ?? 'screenshot',
+            $this->appBaseUrl,
+            $report->getId(),
+        );
+    }
+
+    private function getAdminReportUrl(TechnicalErrorReport $report): string
+    {
+        return sprintf('%s/admin/hlaseni-chyb/%d', $this->appBaseUrl, $report->getId());
+    }
+
+    private function getApiBaseUrl(): string
+    {
+        return sprintf('https://api.github.com/repos/%s/%s', $this->owner, $this->repository);
+    }
+
+    private function assertConfigured(): void
+    {
+        if (! $this->isConfigured()) {
+            throw new RuntimeException('GitHub issue integration is not configured.');
+        }
+    }
+
+    private function normalizeNullableString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        return $value === '' ? null : $value;
+    }
+}

--- a/app/Presentation/Admin/BugReports/BugReportsPresenter.php
+++ b/app/Presentation/Admin/BugReports/BugReportsPresenter.php
@@ -9,6 +9,7 @@ use App\Components\Grids\GridFactory;
 use App\Model\BugReport\BugReportNotificationService;
 use App\Model\BugReport\BugReportScreenshotStorage;
 use App\Model\BugReport\Entity\TechnicalErrorReport;
+use App\Model\BugReport\GitHubIssueService;
 use App\Model\BugReport\Manager\TechnicalErrorReportManager;
 use App\Model\BugReport\Repository\TechnicalErrorReportRepository;
 use Component\Forms\BaseForm;
@@ -29,6 +30,7 @@ final class BugReportsPresenter extends \App\Presentation\Admin\AdminBasePresent
         private TechnicalErrorReportManager $manager,
         private BugReportNotificationService $notificationService,
         private BugReportScreenshotStorage $screenshotStorage,
+        private GitHubIssueService $gitHubIssueService,
         private GridFactory $gridFactory,
     ) {
     }
@@ -137,13 +139,61 @@ final class BugReportsPresenter extends \App\Presentation\Admin\AdminBasePresent
 
             try {
                 $this->notificationService->notifyReply($report, $message);
-                $report->markReplySent($message);
+                $reply = $report->markReplySent($message);
+                if ($report->hasGitHubIssue()) {
+                    try {
+                        $comment = $this->gitHubIssueService->addReplyComment($report, $message);
+                        $reply->markGitHubCommentCreated($comment->getUrl());
+                    } catch (Throwable $e) {
+                        $reply->markGitHubCommentFailed($e->getMessage());
+                        $this->flashMessage('Odpověď autorovi hlášení byla odeslána, ale komentář na GitHub se nepodařilo přidat: '.$e->getMessage(), 'warning');
+                    }
+                }
                 $this->manager->saveNotificationState($report);
-                $this->flashMessage('Odpověď autorovi hlášení byla odeslána.', 'success');
+                if ($reply->getGitHubCommentError() === null) {
+                    $this->flashMessage('Odpověď autorovi hlášení byla odeslána.', 'success');
+                }
             } catch (Throwable $e) {
                 $report->markReplyFailed($e->getMessage());
                 $this->manager->saveNotificationState($report);
                 $this->flashMessage('Odpověď autorovi hlášení se nepodařilo odeslat: '.$e->getMessage(), 'warning');
+            }
+
+            $this->redirect('detail', ['id' => $report->getId()]);
+        };
+
+        return $form;
+    }
+
+    protected function createComponentGitHubIssueForm(): BaseForm
+    {
+        $form = new BaseForm();
+        $form->addHidden('id');
+        $form->addSubmit('send', 'Vytvořit GitHub issue')
+            ->setHtmlAttribute('class', 'btn btn-outline-dark btn-sm');
+
+        $form->onSuccess[] = function (Form $form): void {
+            $values = $form->getValues();
+            $report = $this->repository->findUnresolved((int) $values->id);
+            if (! $report instanceof TechnicalErrorReport) {
+                $this->flashMessage('Hlášení technické chyby nebylo nalezeno nebo už je vyřízené.', 'warning');
+                $this->redirect('default');
+            }
+
+            if ($report->hasGitHubIssue()) {
+                $this->flashMessage('GitHub issue už je u hlášení uložené.', 'info');
+                $this->redirect('detail', ['id' => $report->getId()]);
+            }
+
+            try {
+                $issue = $this->gitHubIssueService->createIssue($report);
+                $report->markGitHubIssueCreated($issue->getNumber(), $issue->getUrl());
+                $this->manager->saveNotificationState($report);
+                $this->flashMessage('GitHub issue bylo vytvořeno.', 'success');
+            } catch (Throwable $e) {
+                $report->markGitHubSyncFailed($e->getMessage());
+                $this->manager->saveNotificationState($report);
+                $this->flashMessage('GitHub issue se nepodařilo vytvořit: '.$e->getMessage(), 'warning');
             }
 
             $this->redirect('detail', ['id' => $report->getId()]);

--- a/app/Presentation/Admin/BugReports/detail.latte
+++ b/app/Presentation/Admin/BugReports/detail.latte
@@ -51,6 +51,23 @@
                     <i class="fi fi-rr-download" aria-hidden="true"></i>
                     Stáhnout screenshot
                 </a>
+                <a
+                    n:if="$report->hasGitHubIssue()"
+                    href="{$report->getGitHubIssueUrl()}"
+                    class="btn btn-outline-dark btn-sm"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-test="admin-bug-report-github-link"
+                >
+                    <i class="fab fa-github" aria-hidden="true"></i>
+                    GitHub #{$report->getGitHubIssueNumber()}
+                </a>
+                {if ! $report->hasGitHubIssue()}
+                    {form gitHubIssueForm, class => 'd-inline'}
+                        {input id, value => $report->getId()}
+                        {input send, data-test => 'admin-bug-report-github-create'}
+                    {/form}
+                {/if}
             </div>
         </div>
     </div>
@@ -122,6 +139,11 @@
                             <div n:foreach="$report->getReplies() as $reply" class="border rounded bg-body-tertiary p-3 mb-3" data-test="admin-bug-report-sent-reply">
                                 <p class="text-body-secondary small mb-2">
                                     Odesláno {$reply->getSentAt()|date:'j. n. Y H:i:s'}
+                                    {if $reply->getGitHubCommentUrl() !== null}
+                                        · <a href="{$reply->getGitHubCommentUrl()}" target="_blank" rel="noopener noreferrer">Komentář na GitHubu</a>
+                                    {elseif $reply->getGitHubCommentError() !== null}
+                                        · GitHub komentář se nepodařilo přidat: {$reply->getGitHubCommentError()}
+                                    {/if}
                                 </p>
                                 <p class="text-pre-wrap mb-0">{$reply->getMessage()}</p>
                             </div>
@@ -189,6 +211,21 @@
                                 {if $report->getScreenshotSize() !== null}
                                     <span class="text-body-secondary small">({$report->getScreenshotSize()} B)</span>
                                 {/if}
+                            {else}
+                                -
+                            {/if}
+                        </dd>
+                        <dt class="col-sm-4">GitHub issue</dt>
+                        <dd class="col-sm-8">
+                            {if $report->hasGitHubIssue()}
+                                <a href="{$report->getGitHubIssueUrl()}" target="_blank" rel="noopener noreferrer" data-test="admin-bug-report-github-link-context">
+                                    #{$report->getGitHubIssueNumber()}
+                                </a>
+                                {if $report->getGitHubIssueCreatedAt() !== null}
+                                    <span class="text-body-secondary small">({$report->getGitHubIssueCreatedAt()|date:'j. n. Y H:i:s'})</span>
+                                {/if}
+                            {elseif $report->getGitHubSyncError() !== null}
+                                <span data-test="admin-bug-report-github-error">Chyba: {$report->getGitHubSyncError()}</span>
                             {else}
                                 -
                             {/if}

--- a/app/config/config.neon
+++ b/app/config/config.neon
@@ -25,6 +25,7 @@ parameters:
     google:
         credentials: %envConfig.google.credentialsPath%
         redirectUri: %envConfig.google.redirectUri%
+    githubIssues: %envConfig.github%
     sentry:
         dsn: %envConfig.sentry.dsn%
         releaseHash: %envConfig.sentry.releaseHash%

--- a/app/config/services.neon
+++ b/app/config/services.neon
@@ -64,6 +64,7 @@ search:
                 - App\Model\Admin\Services\AdminAccessChecker
                 - App\Model\BugReport\BugReportNotificationService
                 - App\Model\BugReport\BugReportService
+                - App\Model\BugReport\GitHubIssueService
                 - App\Model\Invoice\InvoiceAccessChecker
                 - App\Model\Bank\Services\BankAccountPairingRunResult
                 - App\Model\Bank\Services\CiFioTokenValidator
@@ -183,6 +184,10 @@ services:
           recipients: %errorEmails%
           appBaseUrl: %appBaseUrl%
           screenshotStorage: @App\Model\BugReport\BugReportScreenshotStorage
+      )
+    - App\Model\BugReport\GitHubIssueService(
+          config: %githubIssues%
+          appBaseUrl: %appBaseUrl%
       )
     - App\Model\BugReport\BugReportService(appRelease: %sentry.releaseHash%)
 

--- a/migrations/2026/Version20260714120000.php
+++ b/migrations/2026/Version20260714120000.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260714120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Store GitHub issue links for technical error reports';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE technical_error_report ADD github_issue_number INT UNSIGNED DEFAULT NULL, ADD github_issue_url VARCHAR(2048) DEFAULT NULL, ADD github_issue_created_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', ADD github_sync_error LONGTEXT DEFAULT NULL');
+        $this->addSql('ALTER TABLE technical_error_report_reply ADD github_comment_url VARCHAR(2048) DEFAULT NULL, ADD github_comment_error LONGTEXT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE technical_error_report DROP github_issue_number, DROP github_issue_url, DROP github_issue_created_at, DROP github_sync_error');
+        $this->addSql('ALTER TABLE technical_error_report_reply DROP github_comment_url, DROP github_comment_error');
+    }
+}

--- a/tests/unit/BugReport/GitHubIssueServiceTest.php
+++ b/tests/unit/BugReport/GitHubIssueServiceTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\BugReport;
+
+use App\Model\BugReport\Entity\TechnicalErrorReport;
+use Codeception\Test\Unit;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
+use ReflectionProperty;
+use RuntimeException;
+
+use function json_decode;
+
+final class GitHubIssueServiceTest extends Unit
+{
+    public function testCreateIssueSendsReportToGitHub(): void
+    {
+        $history = [];
+        $service = $this->createService([
+            new Response(201, [], '{"number":42,"html_url":"https://github.com/skaut/hospodareni/issues/42"}'),
+        ], $history);
+
+        $issue = $service->createIssue($this->createReport());
+
+        self::assertSame(42, $issue->getNumber());
+        self::assertSame('https://github.com/skaut/hospodareni/issues/42', $issue->getUrl());
+        self::assertCount(1, $history);
+
+        $request = $history[0]['request'];
+        self::assertInstanceOf(RequestInterface::class, $request);
+        self::assertSame('POST', $request->getMethod());
+        self::assertSame('https://api.github.com/repos/skaut/hospodareni/issues', (string) $request->getUri());
+        self::assertSame('Bearer test-token', $request->getHeaderLine('Authorization'));
+
+        $payload = json_decode((string) $request->getBody(), true);
+        self::assertSame('Hlášení technické chyby #123', $payload['title']);
+        self::assertSame(['bug', 'user-report'], $payload['labels']);
+        self::assertStringContainsString('Nefunguje export.', $payload['body']);
+        self::assertStringContainsString('https://h.skauting.cz/admin/hlaseni-chyb/123', $payload['body']);
+        self::assertStringContainsString('```json', $payload['body']);
+    }
+
+    public function testAddReplyCommentSendsCommentToExistingIssue(): void
+    {
+        $history = [];
+        $service = $this->createService([
+            new Response(201, [], '{"html_url":"https://github.com/skaut/hospodareni/issues/42#issuecomment-1"}'),
+        ], $history);
+        $report = $this->createReport();
+        $report->markGitHubIssueCreated(42, 'https://github.com/skaut/hospodareni/issues/42');
+
+        $comment = $service->addReplyComment($report, 'Prosíme o doplnění času chyby.');
+
+        self::assertSame('https://github.com/skaut/hospodareni/issues/42#issuecomment-1', $comment->getUrl());
+        self::assertCount(1, $history);
+
+        $request = $history[0]['request'];
+        self::assertInstanceOf(RequestInterface::class, $request);
+        self::assertSame(
+            'https://api.github.com/repos/skaut/hospodareni/issues/42/comments',
+            (string) $request->getUri(),
+        );
+
+        $payload = json_decode((string) $request->getBody(), true);
+        self::assertStringContainsString('Admin odeslal uživateli odpověď ze systému.', $payload['body']);
+        self::assertStringContainsString('Prosíme o doplnění času chyby.', $payload['body']);
+    }
+
+    public function testUnconfiguredServiceRefusesToCreateIssue(): void
+    {
+        $service = new GitHubIssueService(
+            new Client(['handler' => HandlerStack::create(new MockHandler())]),
+            [],
+            'https://h.skauting.cz',
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('GitHub issue integration is not configured.');
+
+        $service->createIssue($this->createReport());
+    }
+
+    /**
+     * @param list<Response>             $responses
+     * @param list<array<string, mixed>> $history
+     */
+    private function createService(array $responses, array &$history): GitHubIssueService
+    {
+        $mock = new MockHandler($responses);
+        $handlerStack = HandlerStack::create($mock);
+        $handlerStack->push(Middleware::history($history));
+
+        return new GitHubIssueService(
+            new Client(['handler' => $handlerStack]),
+            [
+                'token' => 'test-token',
+                'owner' => 'skaut',
+                'repository' => 'hospodareni',
+                'labels' => ['bug', 'user-report'],
+            ],
+            'https://h.skauting.cz',
+        );
+    }
+
+    private function createReport(): TechnicalErrorReport
+    {
+        $report = new TechnicalErrorReport(
+            'Nefunguje export.',
+            'https://h.skauting.cz/akce/123',
+            1882,
+            'Jana Kvapilová',
+            'jana.kvapilova@example.test',
+            117123,
+            'Středisko: správce akcí - 623.21',
+            23378,
+            'středisko Pozořice',
+            '127.0.0.1',
+            'Test browser',
+            'test-release',
+            ['browser' => ['viewport' => ['innerWidth' => 1200]]],
+            screenshotPath: 'bug-reports/screenshot.jpg',
+            screenshotOriginalName: 'screenshot.jpg',
+            screenshotContentType: 'image/jpeg',
+            screenshotSize: 12,
+        );
+
+        $id = new ReflectionProperty($report, 'id');
+        $id->setAccessible(true);
+        $id->setValue($report, 123);
+
+        return $report;
+    }
+}

--- a/tests/unit/BugReport/TechnicalErrorReportTest.php
+++ b/tests/unit/BugReport/TechnicalErrorReportTest.php
@@ -52,6 +52,42 @@ final class TechnicalErrorReportTest extends Unit
         self::assertSame('Nejde o technickou chybu.', $report->getResolutionMessage());
     }
 
+    public function testGitHubIssueStateCanBeStored(): void
+    {
+        $report = $this->createReport();
+        $createdAt = new DateTimeImmutable('2026-07-14 12:00:00');
+
+        self::assertFalse($report->hasGitHubIssue());
+
+        $report->markGitHubIssueCreated(42, 'https://github.com/skaut/issues/42', $createdAt);
+
+        self::assertTrue($report->hasGitHubIssue());
+        self::assertSame(42, $report->getGitHubIssueNumber());
+        self::assertSame('https://github.com/skaut/issues/42', $report->getGitHubIssueUrl());
+        self::assertSame($createdAt, $report->getGitHubIssueCreatedAt());
+        self::assertNull($report->getGitHubSyncError());
+
+        $report->markGitHubSyncFailed('API error');
+
+        self::assertSame('API error', $report->getGitHubSyncError());
+    }
+
+    public function testReplyCanStoreGitHubCommentState(): void
+    {
+        $report = $this->createReport();
+
+        $reply = $report->markReplySent('Prosíme o doplnění.');
+        $reply->markGitHubCommentCreated('https://github.com/skaut/issues/42#issuecomment-1');
+
+        self::assertSame('https://github.com/skaut/issues/42#issuecomment-1', $reply->getGitHubCommentUrl());
+        self::assertNull($reply->getGitHubCommentError());
+
+        $reply->markGitHubCommentFailed('API error');
+
+        self::assertNull($reply->getGitHubCommentUrl());
+        self::assertSame('API error', $reply->getGitHubCommentError());
+    }
+
     private function createReport(): TechnicalErrorReport
     {
         return new TechnicalErrorReport(


### PR DESCRIPTION
- Added `GitHubIssueService` to create and manage GitHub issues for technical error reports.
- Enhanced `TechnicalErrorReport` and `TechnicalErrorReportReply` with GitHub issue and comment tracking capabilities.
- Updated admin UI to link reports to GitHub issues and display errors or status.
- Introduced configuration options for GitHub issue integration in `.env.local.example`.
- Added database migration to store GitHub-related data.
- Implemented unit tests for `GitHubIssueService` and related functionality.