### PR TITLE
feat: introduce email notifications for invoice access requests

### DIFF
--- a/app/Model/BugReport/BugReportNotificationService.php
+++ b/app/Model/BugReport/BugReportNotificationService.php
@@ -5,25 +5,20 @@ declare(strict_types=1);
 namespace App\Model\BugReport;
 
 use App\Model\BugReport\Entity\TechnicalErrorReport;
-use Nette\Mail\Mailer;
-use Nette\Mail\Message;
-use Nette\Mail\SendmailMailer;
+use App\Model\Mail\SystemEmailTemplate;
+use App\Model\Mail\SystemMailer;
 use Nette\Utils\Json;
 use RuntimeException;
 
 use function array_filter;
 use function array_values;
 use function implode;
-use function parse_url;
-use function sprintf;
 
 final class BugReportNotificationService
 {
     /** @param string[] $recipients */
     public function __construct(
-        private Mailer $debugMailer,
-        private bool $sendEmail,
-        private bool $productionMode,
+        private SystemMailer $systemMailer,
         private array $recipients,
         private string $appBaseUrl,
         private ?BugReportScreenshotStorage $screenshotStorage = null,
@@ -37,35 +32,23 @@ final class BugReportNotificationService
             throw new RuntimeException('No technical error report recipient is configured.');
         }
 
-        $host = parse_url($this->appBaseUrl, PHP_URL_HOST) ?: 'localhost';
-        $message = (new Message())
-            ->setFrom('noreply@'.$host, 'Skautské hospodaření')
-            ->setSubject(sprintf('[Skautské hospodaření] Hlášení technické chyby #%d', $report->getId()))
-            ->setBody($this->createBody($report));
-
-        if ($report->getReporterEmail() !== null) {
-            $message->addReplyTo($report->getReporterEmail(), $report->getReporterDisplayName());
-        }
-
-        $this->attachScreenshot($message, $report);
-
-        foreach ($recipients as $recipient) {
-            $message->addTo($recipient);
-        }
-
-        $mailer = $this->sendEmail && $this->productionMode
-            ? new SendmailMailer()
-            : $this->debugMailer;
-
-        $mailer->send($message);
+        $this->systemMailer->send(
+            SystemEmailTemplate::BUG_REPORT_NOTIFICATION,
+            $this->createNotificationParameters($report),
+            $this->recipientsToMap($recipients),
+            replyTo: $report->getReporterEmail() !== null
+                ? ['email' => $report->getReporterEmail(), 'name' => $report->getReporterDisplayName()]
+                : null,
+            attachments: $this->createAttachments($report),
+        );
     }
 
     public function notifyResolution(TechnicalErrorReport $report, string $messageText): void
     {
         $this->notifyClosure(
             $report,
-            sprintf('[Skautské hospodaření] Hlášení #%d bylo zpracováno', $report->getId()),
-            $this->createResolutionBody($report, $messageText),
+            SystemEmailTemplate::BUG_REPORT_RESOLUTION,
+            ['messageText' => $messageText],
         );
     }
 
@@ -73,8 +56,8 @@ final class BugReportNotificationService
     {
         $this->notifyClosure(
             $report,
-            sprintf('[Skautské hospodaření] Hlášení #%d bylo zamítnuto', $report->getId()),
-            $this->createRejectionBody($report, $messageText),
+            SystemEmailTemplate::BUG_REPORT_REJECTION,
+            ['messageText' => $messageText],
         );
     }
 
@@ -86,42 +69,31 @@ final class BugReportNotificationService
         }
 
         $sender = $this->getReplySender();
-        $message = (new Message())
-            ->setFrom($sender, 'Skautské hospodaření')
-            ->addTo($recipient, $report->getReporterDisplayName())
-            ->setSubject(sprintf('[Skautské hospodaření] Odpověď k hlášení #%d', $report->getId()))
-            ->setBody($this->createReplyBody($report, $messageText));
-
-        $this->send($message);
+        $this->systemMailer->send(
+            SystemEmailTemplate::BUG_REPORT_REPLY,
+            $this->createReporterNotificationParameters($report, ['messageText' => $messageText]),
+            [$recipient => $report->getReporterDisplayName()],
+            fromEmail: $sender,
+        );
     }
 
-    private function notifyClosure(TechnicalErrorReport $report, string $subject, string $body): void
+    /** @param array<string, mixed> $parameters */
+    private function notifyClosure(TechnicalErrorReport $report, SystemEmailTemplate $template, array $parameters): void
     {
         $recipient = $report->getReporterEmail();
         if ($recipient === null) {
             throw new RuntimeException('Technical error report has no reporter email.');
         }
 
-        $host = parse_url($this->appBaseUrl, PHP_URL_HOST) ?: 'localhost';
-        $message = (new Message())
-            ->setFrom('noreply@'.$host, 'Skautské hospodaření')
-            ->addTo($recipient, $report->getReporterDisplayName())
-            ->setSubject($subject)
-            ->setBody($body);
-
-        $this->send($message);
+        $this->systemMailer->send(
+            $template,
+            $this->createReporterNotificationParameters($report, $parameters),
+            [$recipient => $report->getReporterDisplayName()],
+        );
     }
 
-    private function send(Message $message): void
-    {
-        $mailer = $this->sendEmail && $this->productionMode
-            ? new SendmailMailer()
-            : $this->debugMailer;
-
-        $mailer->send($message);
-    }
-
-    private function createBody(TechnicalErrorReport $report): string
+    /** @return array<string, mixed> */
+    private function createNotificationParameters(TechnicalErrorReport $report): array
     {
         $role = array_filter([
             $report->getRoleName(),
@@ -132,106 +104,53 @@ final class BugReportNotificationService
             $report->getUnitId() !== null ? 'ID '.$report->getUnitId() : null,
         ]);
 
-        return implode("\n", [
-            'Byla nahlášena technická chyba ve Skautském hospodaření.',
-            '',
-            'Hlášení: #'.$report->getId(),
-            'Administrace: '.$this->appBaseUrl.'/admin/hlaseni-chyb/'.$report->getId(),
-            'Nahlášeno: '.$report->getCreatedAt()->format('Y-m-d H:i:s P'),
-            'Uživatel: '.$report->getReporterDisplayName().' (ID '.$report->getReporterUserId().')',
-            'E-mail uživatele: '.($report->getReporterEmail() ?? '-'),
-            'Role: '.($role !== [] ? implode(', ', $role) : '-'),
-            'Jednotka: '.($unit !== [] ? implode(', ', $unit) : '-'),
-            'URL chyby: '.($report->getReportedUrl() ?? '-'),
-            'IP: '.($report->getIpAddress() ?? '-'),
-            'Release: '.$report->getAppRelease(),
-            'User-Agent: '.($report->getUserAgent() ?? '-'),
-            'Screenshot: '.($report->hasScreenshot() ? ($report->getScreenshotOriginalName() ?? 'přiložen') : '-'),
-            '',
-            'Popis:',
-            $report->getDescription(),
-            '',
-            'Diagnostika:',
-            Json::encode($report->getDiagnostics(), JSON_PRETTY_PRINT),
+        return $this->createReporterNotificationParameters($report, [
+            'adminUrl' => $this->appBaseUrl.'/admin/hlaseni-chyb/'.$report->getId(),
+            'createdAt' => $report->getCreatedAt()->format('Y-m-d H:i:s P'),
+            'reporterUserId' => $report->getReporterUserId(),
+            'reporterEmail' => $report->getReporterEmail(),
+            'roleLabel' => $role !== [] ? implode(', ', $role) : '-',
+            'unitLabel' => $unit !== [] ? implode(', ', $unit) : '-',
+            'ipAddress' => $report->getIpAddress(),
+            'appRelease' => $report->getAppRelease(),
+            'userAgent' => $report->getUserAgent(),
+            'screenshotLabel' => $report->hasScreenshot() ? ($report->getScreenshotOriginalName() ?? 'přiložen') : '-',
+            'diagnosticsJson' => Json::encode($report->getDiagnostics(), JSON_PRETTY_PRINT),
         ]);
     }
 
-    private function createResolutionBody(TechnicalErrorReport $report, string $messageText): string
+    /**
+     * @param array<string, mixed> $parameters
+     *
+     * @return array<string, mixed>
+     */
+    private function createReporterNotificationParameters(TechnicalErrorReport $report, array $parameters): array
     {
-        return implode("\n", [
-            'Dobrý den,',
-            '',
-            sprintf('vámi nahlášený problém #%d ve Skautském hospodaření byl zpracován.', $report->getId()),
-            'Požadavek byl zpracován a oprava je upravena v nové verzi aplikace.',
-            '',
-            'Zpráva administrátora:',
-            $messageText,
-            '',
-            'Původní hlášení:',
-            $report->getDescription(),
-            '',
-            'URL chyby: '.($report->getReportedUrl() ?? '-'),
-            '',
-            'Děkujeme za nahlášení.',
-            'Skautské hospodaření',
-        ]);
+        return $parameters + [
+            'reportId' => $report->getId(),
+            'reporterDisplayName' => $report->getReporterDisplayName(),
+            'description' => $report->getDescription(),
+            'reportedUrl' => $report->getReportedUrl(),
+        ];
     }
 
-    private function createRejectionBody(TechnicalErrorReport $report, string $messageText): string
-    {
-        return implode("\n", [
-            'Dobrý den,',
-            '',
-            sprintf('vámi nahlášený problém #%d ve Skautském hospodaření byl uzavřen bez opravy.', $report->getId()),
-            '',
-            'Důvod uzavření:',
-            $messageText,
-            '',
-            'Původní hlášení:',
-            $report->getDescription(),
-            '',
-            'URL chyby: '.($report->getReportedUrl() ?? '-'),
-            '',
-            'Děkujeme za nahlášení.',
-            'Skautské hospodaření',
-        ]);
-    }
-
-    private function createReplyBody(TechnicalErrorReport $report, string $messageText): string
-    {
-        return implode("\n", [
-            'Dobrý den,',
-            '',
-            sprintf('posíláme odpověď k vámi nahlášenému problému #%d ve Skautském hospodaření.', $report->getId()),
-            '',
-            'Zpráva administrátora:',
-            $messageText,
-            '',
-            'Původní hlášení:',
-            $report->getDescription(),
-            '',
-            'URL chyby: '.($report->getReportedUrl() ?? '-'),
-            '',
-            'Skautské hospodaření',
-        ]);
-    }
-
-    private function attachScreenshot(Message $message, TechnicalErrorReport $report): void
+    /** @return list<array{name: string, contents: string, contentType: string|null}> */
+    private function createAttachments(TechnicalErrorReport $report): array
     {
         if (! $report->hasScreenshot() || $this->screenshotStorage === null) {
-            return;
+            return [];
         }
 
         $contents = $this->screenshotStorage->getContents($report);
         if ($contents === null) {
-            return;
+            return [];
         }
 
-        $message->addAttachment(
-            $report->getScreenshotOriginalName() ?? 'screenshot',
-            $contents,
-            $report->getScreenshotContentType() ?? BugReportScreenshotStorage::DEFAULT_CONTENT_TYPE,
-        );
+        return [[
+            'name' => $report->getScreenshotOriginalName() ?? 'screenshot',
+            'contents' => $contents,
+            'contentType' => $report->getScreenshotContentType() ?? BugReportScreenshotStorage::DEFAULT_CONTENT_TYPE,
+        ]];
     }
 
     private function getReplySender(): string
@@ -242,5 +161,20 @@ final class BugReportNotificationService
         }
 
         return $recipients[0];
+    }
+
+    /**
+     * @param string[] $recipients
+     *
+     * @return array<string, null>
+     */
+    private function recipientsToMap(array $recipients): array
+    {
+        $mapped = [];
+        foreach ($recipients as $recipient) {
+            $mapped[$recipient] = null;
+        }
+
+        return $mapped;
     }
 }

--- a/app/Model/Mail/SystemEmailTemplate.php
+++ b/app/Model/Mail/SystemEmailTemplate.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\Mail;
+
+use InvalidArgumentException;
+
+use function sprintf;
+
+enum SystemEmailTemplate: string
+{
+    case INVOICE_ACCESS_REQUEST_RECEIVED = 'invoice_access_request_received';
+    case INVOICE_ACCESS_APPROVED = 'invoice_access_approved';
+    case BUG_REPORT_NOTIFICATION = 'bug_report_notification';
+    case BUG_REPORT_RESOLUTION = 'bug_report_resolution';
+    case BUG_REPORT_REJECTION = 'bug_report_rejection';
+    case BUG_REPORT_REPLY = 'bug_report_reply';
+
+    public function templateFile(): string
+    {
+        return match ($this) {
+            self::INVOICE_ACCESS_REQUEST_RECEIVED => __DIR__.'/../emails/userInvoiceAccessRequestReceived.latte',
+            self::INVOICE_ACCESS_APPROVED => __DIR__.'/../emails/userInvoiceAccessApproved.latte',
+            self::BUG_REPORT_NOTIFICATION => __DIR__.'/../emails/adminBugReportNotification.latte',
+            self::BUG_REPORT_RESOLUTION => __DIR__.'/../emails/userBugReportResolution.latte',
+            self::BUG_REPORT_REJECTION => __DIR__.'/../emails/userBugReportRejection.latte',
+            self::BUG_REPORT_REPLY => __DIR__.'/../emails/userBugReportReply.latte',
+        };
+    }
+
+    /** @param array<string, mixed> $parameters */
+    public function subject(array $parameters): string
+    {
+        return match ($this) {
+            self::INVOICE_ACCESS_REQUEST_RECEIVED => 'Žádost o přístup k fakturaci byla přijata',
+            self::INVOICE_ACCESS_APPROVED => 'Fakturace ve Skautském hospodaření je zpřístupněna',
+            self::BUG_REPORT_NOTIFICATION => sprintf('[Skautské hospodaření] Hlášení technické chyby #%d', $this->requireInt($parameters, 'reportId')),
+            self::BUG_REPORT_RESOLUTION => sprintf('[Skautské hospodaření] Hlášení #%d bylo zpracováno', $this->requireInt($parameters, 'reportId')),
+            self::BUG_REPORT_REJECTION => sprintf('[Skautské hospodaření] Hlášení #%d bylo zamítnuto', $this->requireInt($parameters, 'reportId')),
+            self::BUG_REPORT_REPLY => sprintf('[Skautské hospodaření] Odpověď k hlášení #%d', $this->requireInt($parameters, 'reportId')),
+        };
+    }
+
+    /** @param array<string, mixed> $parameters */
+    private function requireInt(array $parameters, string $key): int
+    {
+        $value = $parameters[$key] ?? null;
+        if (! is_int($value)) {
+            throw new InvalidArgumentException(sprintf('System email template parameter "%s" must be an integer.', $key));
+        }
+
+        return $value;
+    }
+}

--- a/app/Model/Mail/SystemMailer.php
+++ b/app/Model/Mail/SystemMailer.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\Mail;
+
+use App\Model\Services\TemplateFactory;
+use Nette\Mail\Mailer;
+use Nette\Mail\Message;
+use Nette\Mail\SendmailMailer;
+
+use function parse_url;
+
+final class SystemMailer
+{
+    public function __construct(
+        private Mailer $debugMailer,
+        private bool $sendEmail,
+        private bool $productionMode,
+        private string $appBaseUrl,
+        private TemplateFactory $templateFactory,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed>                                                  $parameters
+     * @param array<string, string|null>                                            $recipients
+     * @param array{email: string, name?: string|null}|null                         $replyTo
+     * @param list<array{name: string, contents: string, contentType: string|null}> $attachments
+     */
+    public function send(
+        SystemEmailTemplate $template,
+        array $parameters,
+        array $recipients,
+        ?string $fromEmail = null,
+        ?array $replyTo = null,
+        array $attachments = [],
+    ): Message {
+        $message = (new Message())
+            ->setFrom($fromEmail ?? $this->createDefaultSender(), 'Skautské hospodaření')
+            ->setSubject($template->subject($parameters))
+            ->setBody($this->templateFactory->create($template->templateFile(), $parameters));
+
+        foreach ($recipients as $email => $name) {
+            $message->addTo($email, $name);
+        }
+
+        if ($replyTo !== null) {
+            $message->addReplyTo($replyTo['email'], $replyTo['name'] ?? null);
+        }
+
+        foreach ($attachments as $attachment) {
+            $message->addAttachment(
+                $attachment['name'],
+                $attachment['contents'],
+                $attachment['contentType'],
+            );
+        }
+
+        $this->createMailer()->send($message);
+
+        return $message;
+    }
+
+    private function createDefaultSender(): string
+    {
+        $host = parse_url($this->appBaseUrl, PHP_URL_HOST) ?: 'localhost';
+
+        return 'noreply@'.$host;
+    }
+
+    private function createMailer(): Mailer
+    {
+        return $this->sendEmail && $this->productionMode
+            ? new SendmailMailer()
+            : $this->debugMailer;
+    }
+}

--- a/app/Model/User/Entity/InvoiceAccessRequest.php
+++ b/app/Model/User/Entity/InvoiceAccessRequest.php
@@ -32,6 +32,9 @@ class InvoiceAccessRequest extends AbstractIdEntity
     #[Column(name: 'display_name', type: Types::STRING, length: 255)]
     private string $displayName;
 
+    #[Column(name: 'requester_email', type: Types::STRING, length: 255, nullable: true)]
+    private ?string $requesterEmail;
+
     #[Column(name: 'note', type: Types::TEXT)]
     private string $note;
 
@@ -49,6 +52,7 @@ class InvoiceAccessRequest extends AbstractIdEntity
         ?int $unitId,
         ?int $roleId,
         string $displayName,
+        ?string $requesterEmail,
         string $note,
         ?DateTimeImmutable $createdAt = null,
     ) {
@@ -60,6 +64,7 @@ class InvoiceAccessRequest extends AbstractIdEntity
         $this->unitId = $unitId;
         $this->roleId = $roleId;
         $this->displayName = $displayName;
+        $this->requesterEmail = $requesterEmail;
         $this->note = $note;
         $this->createdAt = $createdAt ?? new DateTimeImmutable();
     }
@@ -94,6 +99,11 @@ class InvoiceAccessRequest extends AbstractIdEntity
     public function getDisplayName(): string
     {
         return $this->displayName;
+    }
+
+    public function getRequesterEmail(): ?string
+    {
+        return $this->requesterEmail;
     }
 
     public function getNote(): string

--- a/app/Model/User/InvoiceAccessNotificationService.php
+++ b/app/Model/User/InvoiceAccessNotificationService.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\User;
+
+use App\Model\Mail\SystemEmailTemplate;
+use App\Model\Mail\SystemMailer;
+use App\Model\User\Entity\InvoiceAccessRequest;
+
+final class InvoiceAccessNotificationService
+{
+    public function __construct(private SystemMailer $systemMailer)
+    {
+    }
+
+    public function notifyRequestReceived(InvoiceAccessRequest $request): bool
+    {
+        $recipient = $request->getRequesterEmail();
+        if ($recipient === null) {
+            return false;
+        }
+
+        $this->systemMailer->send(
+            SystemEmailTemplate::INVOICE_ACCESS_REQUEST_RECEIVED,
+            [],
+            [$recipient => $request->getDisplayName()],
+        );
+
+        return true;
+    }
+
+    public function notifyAccessApproved(InvoiceAccessRequest $request): bool
+    {
+        $recipient = $request->getRequesterEmail();
+        if ($recipient === null) {
+            return false;
+        }
+
+        $this->systemMailer->send(
+            SystemEmailTemplate::INVOICE_ACCESS_APPROVED,
+            [],
+            [$recipient => $request->getDisplayName()],
+        );
+
+        return true;
+    }
+}

--- a/app/Model/User/Manager/InvoiceAccessRequestManager.php
+++ b/app/Model/User/Manager/InvoiceAccessRequestManager.php
@@ -31,15 +31,16 @@ class InvoiceAccessRequestManager extends AbstractManager
         ?int $unitId,
         ?int $roleId,
         string $displayName,
+        ?string $requesterEmail,
         string $note,
     ): InvoiceAccessRequest {
-        return $this->em->wrapInTransaction(function () use ($userId, $unitId, $roleId, $displayName, $note): InvoiceAccessRequest {
+        return $this->em->wrapInTransaction(function () use ($userId, $unitId, $roleId, $displayName, $requesterEmail, $note): InvoiceAccessRequest {
             $existingRequest = $this->requestRepository->findOpenByUserId($userId);
             if ($existingRequest instanceof InvoiceAccessRequest) {
                 return $existingRequest;
             }
 
-            $request = new InvoiceAccessRequest($userId, $unitId, $roleId, $displayName, $note);
+            $request = new InvoiceAccessRequest($userId, $unitId, $roleId, $displayName, $requesterEmail, $note);
             $this->em->persist($request);
             $this->em->flush();
 

--- a/app/Model/emails/adminBugReportNotification.latte
+++ b/app/Model/emails/adminBugReportNotification.latte
@@ -1,0 +1,20 @@
+Byla nahlášena technická chyba ve Skautském hospodaření.
+
+Hlášení: #{$reportId}
+Administrace: {$adminUrl}
+Nahlášeno: {$createdAt}
+Uživatel: {$reporterDisplayName} (ID {$reporterUserId})
+E-mail uživatele: {$reporterEmail ?? '-'}
+Role: {$roleLabel}
+Jednotka: {$unitLabel}
+URL chyby: {$reportedUrl ?? '-'}
+IP: {$ipAddress ?? '-'}
+Release: {$appRelease}
+User-Agent: {$userAgent ?? '-'}
+Screenshot: {$screenshotLabel}
+
+Popis:
+{$description}
+
+Diagnostika:
+{$diagnosticsJson|noescape}

--- a/app/Model/emails/userBugReportRejection.latte
+++ b/app/Model/emails/userBugReportRejection.latte
@@ -1,0 +1,14 @@
+Dobrý den,
+
+vámi nahlášený problém #{$reportId} ve Skautském hospodaření byl uzavřen bez opravy.
+
+Důvod uzavření:
+{$messageText}
+
+Původní hlášení:
+{$description}
+
+URL chyby: {$reportedUrl ?? '-'}
+
+Děkujeme za nahlášení.
+Skautské hospodaření

--- a/app/Model/emails/userBugReportReply.latte
+++ b/app/Model/emails/userBugReportReply.latte
@@ -1,0 +1,13 @@
+Dobrý den,
+
+posíláme odpověď k vámi nahlášenému problému #{$reportId} ve Skautském hospodaření.
+
+Zpráva administrátora:
+{$messageText}
+
+Původní hlášení:
+{$description}
+
+URL chyby: {$reportedUrl ?? '-'}
+
+Skautské hospodaření

--- a/app/Model/emails/userBugReportResolution.latte
+++ b/app/Model/emails/userBugReportResolution.latte
@@ -1,0 +1,15 @@
+Dobrý den,
+
+vámi nahlášený problém #{$reportId} ve Skautském hospodaření byl zpracován.
+Požadavek byl zpracován a oprava je upravena v nové verzi aplikace.
+
+Zpráva administrátora:
+{$messageText}
+
+Původní hlášení:
+{$description}
+
+URL chyby: {$reportedUrl ?? '-'}
+
+Děkujeme za nahlášení.
+Skautské hospodaření

--- a/app/Model/emails/userInvoiceAccessApproved.latte
+++ b/app/Model/emails/userInvoiceAccessApproved.latte
@@ -1,0 +1,8 @@
+Dobrý den,
+
+váš předběžný přístup k fakturaci ve Skautském hospodaření byl schválen.
+
+Fakturace je nyní ve vašem účtu dostupná. Můžete ji otevřít po přihlášení v části Platby -> Faktury.
+
+S pozdravem
+Skautské hospodaření

--- a/app/Model/emails/userInvoiceAccessRequestReceived.latte
+++ b/app/Model/emails/userInvoiceAccessRequestReceived.latte
@@ -1,0 +1,10 @@
+Dobrý den,
+
+děkujeme za váš zájem o předběžný přístup k fakturaci ve Skautském hospodaření.
+
+Vaši žádost jsme přijali. Přístup vám udělíme, jakmile to bude technicky možné. O zpřístupnění fakturace vás budeme informovat e-mailem.
+
+Fakturace je aktuálně v beta provozu. Po vytvoření si prosím faktury pro jistotu ukládejte také mimo systém. Rozložení prvků, jednotlivé kroky a celý proces práce s fakturami se ještě mohou měnit na základě uživatelských podnětů.
+
+S pozdravem
+Skautské hospodaření

--- a/app/Presentation/Admin/InvoiceAccess/InvoiceAccessPresenter.php
+++ b/app/Presentation/Admin/InvoiceAccess/InvoiceAccessPresenter.php
@@ -7,6 +7,7 @@ namespace App\Presentation\Admin\InvoiceAccess;
 use App\Model\Invoice\InvoiceAccessChecker;
 use App\Model\User\Entity\InvoiceAccessRequest;
 use App\Model\User\Entity\InvoiceAccessUser;
+use App\Model\User\InvoiceAccessNotificationService;
 use App\Model\User\Manager\InvoiceAccessRequestManager;
 use App\Model\User\Manager\InvoiceAccessUserManager;
 use App\Model\User\Repository\InvoiceAccessRequestRepository;
@@ -14,6 +15,7 @@ use App\Model\User\Repository\InvoiceAccessUserRepository;
 use Component\Forms\BaseForm;
 use Nette\Application\AbortException;
 use Nette\Application\UI\Form;
+use Throwable;
 
 final class InvoiceAccessPresenter extends \App\Presentation\Admin\AdminBasePresenter
 {
@@ -23,6 +25,7 @@ final class InvoiceAccessPresenter extends \App\Presentation\Admin\AdminBasePres
         private InvoiceAccessRequestRepository $requestRepository,
         private InvoiceAccessRequestManager $requestManager,
         private InvoiceAccessChecker $invoiceAccessChecker,
+        private InvoiceAccessNotificationService $notificationService,
     ) {
     }
 
@@ -52,7 +55,18 @@ final class InvoiceAccessPresenter extends \App\Presentation\Admin\AdminBasePres
         }
 
         $this->requestManager->approve($request);
-        $this->flashMessage('Přístup k fakturaci byl schválen.', 'success');
+        try {
+            $notificationSent = $this->notificationService->notifyAccessApproved($request);
+            $this->flashMessage(
+                $notificationSent
+                    ? 'Přístup k fakturaci byl schválen a žadatel byl informován e-mailem.'
+                    : 'Přístup k fakturaci byl schválen, ale u žádosti není uložený e-mail žadatele.',
+                $notificationSent ? 'success' : 'warning',
+            );
+        } catch (Throwable) {
+            $this->flashMessage('Přístup k fakturaci byl schválen, ale e-mail žadateli se nepodařilo odeslat.', 'warning');
+        }
+
         $this->redirect('default');
     }
 

--- a/app/Presentation/Admin/InvoiceAccess/default.latte
+++ b/app/Presentation/Admin/InvoiceAccess/default.latte
@@ -32,6 +32,7 @@
                     <tr>
                         <th>User ID</th>
                         <th>Uživatel</th>
+                        <th>E-mail</th>
                         <th>Jednotka</th>
                         <th>Role</th>
                         <th>Poznámka</th>
@@ -46,6 +47,7 @@
                     >
                         <td><code>{$request->getUserId()}</code></td>
                         <td>{$request->getDisplayName()}</td>
+                        <td>{$request->getRequesterEmail() ?? '-'}</td>
                         <td>{$request->getUnitId() ?? '-'}</td>
                         <td>{$request->getRoleId() ?? '-'}</td>
                         <td>{$request->getNote() === '' ? '-' : $request->getNote()}</td>

--- a/app/Presentation/InvoiceAccess/InvoiceAccessGuard.php
+++ b/app/Presentation/InvoiceAccess/InvoiceAccessGuard.php
@@ -6,14 +6,19 @@ namespace App\Presentation\InvoiceAccess;
 
 use App\Model\Invoice\InvoiceAccessChecker;
 use App\Model\User\Entity\InvoiceAccessRequest;
+use App\Model\User\InvoiceAccessNotificationService;
 use App\Model\User\Manager\InvoiceAccessRequestManager;
 use App\Model\User\Repository\InvoiceAccessRequestRepository;
 use Component\Forms\BaseForm;
 use Nette\Application\AbortException;
 use Nette\Forms\Form;
+use Nette\Utils\Validators;
 use stdClass;
+use Throwable;
 
+use function get_object_vars;
 use function is_string;
+use function trim;
 
 trait InvoiceAccessGuard
 {
@@ -23,14 +28,18 @@ trait InvoiceAccessGuard
 
     private InvoiceAccessRequestManager $invoiceAccessRequestManager;
 
+    private InvoiceAccessNotificationService $invoiceAccessNotificationService;
+
     public function injectInvoiceAccessGuard(
         InvoiceAccessChecker $invoiceAccessChecker,
         InvoiceAccessRequestRepository $invoiceAccessRequestRepository,
         InvoiceAccessRequestManager $invoiceAccessRequestManager,
+        InvoiceAccessNotificationService $invoiceAccessNotificationService,
     ): void {
         $this->invoiceAccessChecker = $invoiceAccessChecker;
         $this->invoiceAccessRequestRepository = $invoiceAccessRequestRepository;
         $this->invoiceAccessRequestManager = $invoiceAccessRequestManager;
+        $this->invoiceAccessNotificationService = $invoiceAccessNotificationService;
     }
 
     /**
@@ -98,15 +107,27 @@ trait InvoiceAccessGuard
         }
 
         $values = $form->getValues();
-        $this->invoiceAccessRequestManager->createRequest(
+        $request = $this->invoiceAccessRequestManager->createRequest(
             $userId,
             $this->unitId->toInt(),
             $this->userService->getRoleId(),
             $this->resolveInvoiceAccessDisplayName($userId),
+            $this->resolveInvoiceAccessRequesterEmail(),
             (string) $values->note,
         );
 
-        $this->flashMessage('Žádost o zařazení do testovacího programu byla odeslána.', 'success');
+        try {
+            $notificationSent = $this->invoiceAccessNotificationService->notifyRequestReceived($request);
+            $this->flashMessage(
+                $notificationSent
+                    ? 'Žádost o zařazení do testovacího programu byla odeslána.'
+                    : 'Žádost o zařazení do testovacího programu byla odeslána. Ve SkautISu ale nemáte uložený e-mail pro potvrzení.',
+                $notificationSent ? 'success' : 'warning',
+            );
+        } catch (Throwable) {
+            $this->flashMessage('Žádost o zařazení do testovacího programu byla odeslána, ale potvrzovací e-mail se nepodařilo odeslat.', 'warning');
+        }
+
         $this->redirect('default');
     }
 
@@ -125,5 +146,41 @@ trait InvoiceAccessGuard
         }
 
         return 'user_id '.$userId;
+    }
+
+    private function resolveInvoiceAccessRequesterEmail(): ?string
+    {
+        try {
+            $email = $this->resolveEmailFromSkautisDetail(get_object_vars($this->userService->getUserDetail()));
+            if ($email !== null) {
+                return $email;
+            }
+        } catch (Throwable) {
+            // Fall through to personal detail.
+        }
+
+        try {
+            return $this->resolveEmailFromSkautisDetail(get_object_vars($this->userService->getPersonalDetail()));
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    /** @param array<string, mixed> $detail */
+    private function resolveEmailFromSkautisDetail(array $detail): ?string
+    {
+        foreach (['Email', 'PersonEmail', 'UserEmail', 'Mail'] as $key) {
+            $email = $detail[$key] ?? null;
+            if (! is_string($email)) {
+                continue;
+            }
+
+            $email = trim($email);
+            if ($email !== '' && Validators::isEmail($email)) {
+                return $email;
+            }
+        }
+
+        return null;
     }
 }

--- a/app/config/services.neon
+++ b/app/config/services.neon
@@ -174,13 +174,18 @@ services:
 
     # Mail
     - App\Model\Mail\MailerFactory(@nette.mailer, %sendEmail%)
+    - App\Model\Mail\SystemMailer(
+          debugMailer: @nette.mailer
+          sendEmail: %sendEmail%
+          productionMode: %productionMode%
+          appBaseUrl: %appBaseUrl%
+      )
+    - App\Model\User\InvoiceAccessNotificationService
     - App\Model\BugReport\BugReportScreenshotStorage(
           filesystem: @League\Flysystem\Filesystem
           uploadDirectory: %uploadDirectory%
       )
     - App\Model\BugReport\BugReportNotificationService(
-          sendEmail: %sendEmail%
-          productionMode: %productionMode%
           recipients: %errorEmails%
           appBaseUrl: %appBaseUrl%
           screenshotStorage: @App\Model\BugReport\BugReportScreenshotStorage

--- a/migrations/2026/Version20260715120000.php
+++ b/migrations/2026/Version20260715120000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260715120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Store requester email for invoice access requests';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE invoice_access_request ADD requester_email VARCHAR(255) DEFAULT NULL AFTER display_name');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE invoice_access_request DROP requester_email');
+    }
+}

--- a/tests/unit/BugReport/BugReportNotificationServiceTest.php
+++ b/tests/unit/BugReport/BugReportNotificationServiceTest.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace App\Model\BugReport;
 
 use App\Model\BugReport\Entity\TechnicalErrorReport;
+use App\Model\Mail\SystemMailer;
+use App\Model\Services\TemplateFactory;
 use Codeception\Test\Unit;
+use Latte\Engine;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Local\LocalFilesystemAdapter;
+use Nette\Bridges\ApplicationLatte\LatteFactory;
 use Nette\Mail\Mailer;
 use Nette\Mail\Message;
 use Nette\Utils\FileSystem as FileSystemUtil;
@@ -29,13 +33,7 @@ final class BugReportNotificationServiceTest extends Unit
             }
         };
 
-        $service = new BugReportNotificationService(
-            $mailer,
-            false,
-            false,
-            ['admin@example.test'],
-            'https://h.skauting.cz',
-        );
+        $service = $this->createService($mailer);
 
         $service->notify($this->createReport('jana.kvapilova@example.test'));
 
@@ -61,13 +59,7 @@ final class BugReportNotificationServiceTest extends Unit
             }
         };
 
-        $service = new BugReportNotificationService(
-            $mailer,
-            false,
-            false,
-            ['admin@example.test'],
-            'https://h.skauting.cz',
-        );
+        $service = $this->createService($mailer);
 
         $service->notify($this->createReport(null));
 
@@ -91,12 +83,8 @@ final class BugReportNotificationServiceTest extends Unit
         FileSystemUtil::createDir(dirname($directory.'/'.$relativePath));
         file_put_contents($directory.'/'.$relativePath, 'jpeg-content');
 
-        $service = new BugReportNotificationService(
+        $service = $this->createService(
             $mailer,
-            false,
-            false,
-            ['admin@example.test'],
-            'https://h.skauting.cz',
             new BugReportScreenshotStorage(
                 new Filesystem(new LocalFilesystemAdapter($directory)),
                 $directory,
@@ -129,13 +117,7 @@ final class BugReportNotificationServiceTest extends Unit
             }
         };
 
-        $service = new BugReportNotificationService(
-            $mailer,
-            false,
-            false,
-            ['admin@example.test'],
-            'https://h.skauting.cz',
-        );
+        $service = $this->createService($mailer);
 
         $service->notifyResolution(
             $this->createReport('jana.kvapilova@example.test'),
@@ -160,13 +142,7 @@ final class BugReportNotificationServiceTest extends Unit
             }
         };
 
-        $service = new BugReportNotificationService(
-            $mailer,
-            false,
-            false,
-            ['admin@example.test'],
-            'https://h.skauting.cz',
-        );
+        $service = $this->createService($mailer);
 
         $service->notifyRejection(
             $this->createReport('jana.kvapilova@example.test'),
@@ -191,13 +167,7 @@ final class BugReportNotificationServiceTest extends Unit
             }
         };
 
-        $service = new BugReportNotificationService(
-            $mailer,
-            false,
-            false,
-            ['admin@example.test'],
-            'https://h.skauting.cz',
-        );
+        $service = $this->createService($mailer);
 
         $service->notifyReply(
             $this->createReport('jana.kvapilova@example.test'),
@@ -243,5 +213,26 @@ final class BugReportNotificationServiceTest extends Unit
         $id->setValue($report, 123);
 
         return $report;
+    }
+
+    private function createService(Mailer $mailer, ?BugReportScreenshotStorage $screenshotStorage = null): BugReportNotificationService
+    {
+        return new BugReportNotificationService(
+            new SystemMailer(
+                $mailer,
+                false,
+                false,
+                'https://h.skauting.cz',
+                new TemplateFactory(new class implements LatteFactory {
+                    public function create(): Engine
+                    {
+                        return new Engine();
+                    }
+                }),
+            ),
+            ['admin@example.test'],
+            'https://h.skauting.cz',
+            $screenshotStorage,
+        );
     }
 }

--- a/tests/unit/User/InvoiceAccessNotificationServiceTest.php
+++ b/tests/unit/User/InvoiceAccessNotificationServiceTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\User;
+
+use App\Model\Mail\SystemMailer;
+use App\Model\Services\TemplateFactory;
+use App\Model\User\Entity\InvoiceAccessRequest;
+use App\Model\User\InvoiceAccessNotificationService;
+use Codeception\Test\Unit;
+use Latte\Engine;
+use Nette\Bridges\ApplicationLatte\LatteFactory;
+use Nette\Mail\Mailer;
+use Nette\Mail\Message;
+
+final class InvoiceAccessNotificationServiceTest extends Unit
+{
+    public function testRequestReceivedNotificationIsSentToRequester(): void
+    {
+        $mailer = $this->createMailer();
+        $service = new InvoiceAccessNotificationService($this->createSystemMailer($mailer));
+
+        $service->notifyRequestReceived($this->createRequest('jana.kvapilova@example.test'));
+
+        self::assertInstanceOf(Message::class, $mailer->message);
+        self::assertSame(['noreply@h.skauting.cz' => 'Skautské hospodaření'], $mailer->message->getHeader('From'));
+        self::assertSame(['jana.kvapilova@example.test' => 'Jana Kvapilová'], $mailer->message->getHeader('To'));
+        self::assertSame('Žádost o přístup k fakturaci byla přijata', (string) $mailer->message->getSubject());
+        self::assertStringContainsString('Přístup vám udělíme, jakmile to bude technicky možné.', (string) $mailer->message->getBody());
+        self::assertStringContainsString('Po vytvoření si prosím faktury pro jistotu ukládejte také mimo systém.', (string) $mailer->message->getBody());
+        self::assertStringContainsString('se ještě mohou měnit na základě uživatelských podnětů.', (string) $mailer->message->getBody());
+    }
+
+    public function testAccessApprovedNotificationIsSentToRequester(): void
+    {
+        $mailer = $this->createMailer();
+        $service = new InvoiceAccessNotificationService($this->createSystemMailer($mailer));
+
+        $service->notifyAccessApproved($this->createRequest('jana.kvapilova@example.test'));
+
+        self::assertInstanceOf(Message::class, $mailer->message);
+        self::assertSame(['jana.kvapilova@example.test' => 'Jana Kvapilová'], $mailer->message->getHeader('To'));
+        self::assertSame('Fakturace ve Skautském hospodaření je zpřístupněna', (string) $mailer->message->getSubject());
+        self::assertStringContainsString('váš předběžný přístup k fakturaci ve Skautském hospodaření byl schválen.', (string) $mailer->message->getBody());
+        self::assertStringContainsString('Platby -> Faktury', (string) $mailer->message->getBody());
+    }
+
+    public function testNoNotificationIsSentWithoutRequesterEmail(): void
+    {
+        $mailer = $this->createMailer();
+        $service = new InvoiceAccessNotificationService($this->createSystemMailer($mailer));
+
+        self::assertFalse($service->notifyRequestReceived($this->createRequest(null)));
+        self::assertFalse($service->notifyAccessApproved($this->createRequest(null)));
+
+        self::assertNull($mailer->message);
+    }
+
+    private function createRequest(?string $requesterEmail): InvoiceAccessRequest
+    {
+        return new InvoiceAccessRequest(
+            1882,
+            23378,
+            117123,
+            'Jana Kvapilová',
+            $requesterEmail,
+            'Chci testovat fakturaci.',
+        );
+    }
+
+    private function createMailer(): CapturingMailer
+    {
+        return new CapturingMailer();
+    }
+
+    private function createSystemMailer(Mailer $mailer): SystemMailer
+    {
+        return new SystemMailer(
+            $mailer,
+            false,
+            false,
+            'https://h.skauting.cz',
+            new TemplateFactory(new class implements LatteFactory {
+                public function create(): Engine
+                {
+                    return new Engine();
+                }
+            }),
+        );
+    }
+}
+
+final class CapturingMailer implements Mailer
+{
+    public ?Message $message = null;
+
+    public function send(Message $mail): void
+    {
+        $this->message = $mail;
+    }
+}


### PR DESCRIPTION
- Added `InvoiceAccessNotificationService` to send email notifications for request receipt and access approval.
- Enhanced `InvoiceAccessRequest` to store and retrieve requester email addresses.
- Updated related forms, repositories, and managers to handle email fields.
- Modified UI elements to display requester email for administrative visibility.
- Included database migration to add `requester_email` column.
- Added unit tests for `InvoiceAccessNotificationService`.